### PR TITLE
Automatically match QoS settings across the bridge

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -131,13 +131,14 @@ Consider the following scenario:
 1. Publisher *A* publishes on topic "chatter" with a QoS reliability setting of *reliable*.
 2. Publisher *B* publishes on topic "chatter" with a QoS reliability setting of *best effort*.
 3. In order to receive a message from *B*, we must create a subscription with a QoS reliability setting of *best effort*.
-4. The subscription will also receive messages from *A*, since *best effort* subscriptions also match with *reliable* publishers.
+4. The subscription will also receive messages from *A*, since *best effort* subscriptions also matches with *reliable* publishers.
 
 If we cannot distinguish whether a message came from publisher *A* or publisher *B*, then we cannot know what QoS settings to use for the message when publishing into another domain.
 
 Instead, the proposed approach will do as best it can to ensure all messages make it across the bridge.
 The bridge will evaluate the QoS settings of all publishers and modifiy the QoS settings of the bridges subscription and publisher
 such that it matches the majority of the available publishers for a given topic.
+For example, given publisher *A* and publisher *B* from the aforementioned scenario, the bridge would select a reliability setting of best effort since it matches with both publishers.
 
 The bridge will decide on the QoS settings as soon as one or more publishers is available.
 This means it is possible that publishers joining after the topic bridge is created may have compatibility issues, and fail to have their messages bridged.
@@ -224,8 +225,8 @@ For example, the bridge could continuously monitor for new publishers and re-cre
 Though, it is possible that some messages may be missed during the re-creation of the subscription.
 
 Pros:
-- Better suited to systems where publishers are created/destroyed during runtime
+- Better suited to systems where publishers with different QoS settings are created/destroyed during runtime
 
 Cons:
-- Not obvious how to handle missing out on messages during subscription re-creation
+- Not obvious how to handle missing messages during subscription re-creation
 - Substantially more complex to implement.

--- a/doc/design.md
+++ b/doc/design.md
@@ -46,7 +46,7 @@ For example, a publisher with reliability policy set to "best effort" should con
 If there are multiple publishers on the same topic, but with different QoS settings, it would be nice if the bridge could preserve each stream of data.
 For example, if there is one publisher using "best effort" and another publisher using "reliable" on the same topic (with the same domain ID) and a bridge is made,
 then the bridge should forward data as "best effort" for the first publisher and as "reliable" for the second publisher into the output domain.
-Unforunately, this may not be possible due to technical limitations so we leave this as a soft requirement.
+Unfortunately, this may not be possible due to technical limitations so we leave this as a soft requirement.
 Refer to the *QoS mapping* section of the proposed approach below for a more detailed discussion.
 
 Since remotely querying the *history* and *depth* QoS policies is not possible in many implementations (e.g. it is not required by the DDS spec),
@@ -125,7 +125,7 @@ The solution is to have the bridge wait until a publisher becomes available befo
 #### Multiple publishers
 
 As mentioned in the requirements, if there are multiple publishers on the same topic, it would be nice if the bridge could preserve multiple streams of data, each with their own QoS settings.
-Unforunately, this is technically challenging because it is difficult to associate a ROS message received by a subscription with the publisher that originally published the message.
+Unfortunately, this is technically challenging because it is difficult to associate a ROS message received by a subscription with the publisher that originally published the message.
 Consider the following scenario:
 
 1. Publisher *A* publishes on topic "chatter" with a QoS reliability setting of *reliable*.

--- a/src/domain_bridge/domain_bridge.cpp
+++ b/src/domain_bridge/domain_bridge.cpp
@@ -192,7 +192,7 @@ public:
 
         // Get typesupport handle
         auto typesupport_handle = rosbag2_cpp::get_typesupport_handle(
-          type, "rosidl_typesupport_cpp", loaded_typesupports_[type]);
+          type, "rosidl_typesupport_cpp", loaded_typesupports_.at(type));
 
         // Create publisher for the 'to_domain'
         // The publisher should be created first so it is available to the subscription callback

--- a/src/domain_bridge/domain_bridge.cpp
+++ b/src/domain_bridge/domain_bridge.cpp
@@ -14,12 +14,18 @@
 
 #include "domain_bridge/domain_bridge.hpp"
 
+// Silly cpplint thinks this is a C system header
+#include <optional>
+
+#include <atomic>
 #include <cstddef>
+#include <functional>
 #include <iostream>
 #include <map>
 #include <memory>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -28,8 +34,9 @@
 #include "domain_bridge/topic_bridge.hpp"
 #include "domain_bridge/topic_bridge_options.hpp"
 
-#include "rclcpp/rclcpp.hpp"
 #include "rclcpp/executor.hpp"
+#include "rclcpp/expand_topic_or_service_name.hpp"
+#include "rclcpp/rclcpp.hpp"
 #include "rcutils/logging_macros.h"
 #include "rosbag2_cpp/typesupport_helpers.hpp"
 #include "rmw/types.h"
@@ -48,12 +55,20 @@ public:
   using TopicBridgeMap = std::map<
     TopicBridge,
     std::pair<std::shared_ptr<GenericPublisher>, std::shared_ptr<GenericSubscription>>>;
+  using TypesupportMap = std::unordered_map<
+    std::string, std::shared_ptr<rcpputils::SharedLibrary>>;
 
   explicit DomainBridgeImpl(const DomainBridgeOptions & options)
   : options_(options)
   {}
 
-  ~DomainBridgeImpl() = default;
+  ~DomainBridgeImpl()
+  {
+    shutting_down_.store(true);
+    for (const auto & t : waiting_threads_) {
+      t->join();
+    }
+  }
 
   rclcpp::Context::SharedPtr create_context_with_domain_id(std::size_t domain_id)
   {
@@ -91,6 +106,17 @@ public:
     return domain_id_node_pair->second;
   }
 
+  /// Load typesupport library into a cache.
+  void load_typesupport_library(std::string type)
+  {
+    if (loaded_typesupports_.find(type) != loaded_typesupports_.end()) {
+      // Typesupport library already loaded
+      return;
+    }
+    loaded_typesupports_[type] = rosbag2_cpp::get_typesupport_library(
+      type, "rosidl_typesupport_cpp");
+  }
+
   /// Get the QoS to use for a topic bridge.
   /**
    * Queries QoS of existing publishers and returns QoS that is compatibile
@@ -98,8 +124,10 @@ public:
    * If possible, the returned QoS will exactly match those of the publishers.
    *
    * If the existing publishers do not have matching QoS settings, then a warning is emitted.
+   *
+   * If there are no publishers, then no QoS is returned (i.e. the optional object is not set).
    */
-  rclcpp::QoS get_topic_qos(std::string topic, rclcpp::Node::SharedPtr node)
+  std::optional<rclcpp::QoS> get_topic_qos(std::string topic, rclcpp::Node::SharedPtr node)
   {
     // TODO(jacobperron): replace this with common implementation when it is available.
     //       See: https://github.com/ros2/rosbag2/issues/601
@@ -114,7 +142,7 @@ public:
 
     // If there are no publishers, return default QoS
     if (num_endpoints < 1u) {
-      return rclcpp::QoS(10);
+      return {};
     }
 
     // Initialize QoS arbitrarily
@@ -136,7 +164,7 @@ public:
 
     // If not all publishers have a "reliable" policy, then use a "best effort" policy
     // and print a warning
-    if (reliable_count != num_endpoints) {
+    if (reliable_count > 0u && reliable_count != num_endpoints) {
       result_qos.best_effort();
       std::cerr << "Some, but not all, publishers on topic '" << topic << "' on domain ID " <<
         std::to_string(node->get_node_options().context()->get_domain_id()) <<
@@ -146,7 +174,7 @@ public:
 
     // If not all publishers have a "transient local" policy, then use a "volatile" policy
     // and print a warning
-    if (transient_local_count != num_endpoints) {
+    if (transient_local_count > 0u && transient_local_count != num_endpoints) {
       result_qos.durability_volatile();
       std::cerr << "Some, but not all, publishers on topic '" << topic << "' on domain ID " <<
         std::to_string(node->get_node_options().context()->get_domain_id()) <<
@@ -197,14 +225,52 @@ public:
     return subscription;
   }
 
+  void register_on_publisher_qos_ready_callback(
+    std::string topic,
+    rclcpp::Node::SharedPtr node,
+    std::function<void(const rclcpp::QoS)> callback)
+  {
+    // If the QoS is already avaiable, trigger the callback immediately
+    auto opt_qos = this->get_topic_qos(topic, node);
+    if (opt_qos) {
+      const rclcpp::QoS & qos = opt_qos.value();
+      callback(qos);
+      return;
+    }
+
+    // Create a thread that waits for a publisher to become availble
+    auto invoke_callback_when_qos_ready = [this, topic, node, callback]()
+      {
+        while (!this->shutting_down_.load()) {
+          // TODO(jacobperron): Use graph events
+          auto opt_qos = this->get_topic_qos(topic, node);
+          if (opt_qos) {
+            const rclcpp::QoS & qos = opt_qos.value();
+            callback(qos);
+            return;
+          }
+          std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+      };
+    auto waiting_thread = std::make_shared<std::thread>(invoke_callback_when_qos_ready);
+    waiting_threads_.push_back(waiting_thread);
+  }
+
   void bridge_topic(
     const TopicBridge & topic_bridge,
-    const TopicBridgeOptions & options)
+    const TopicBridgeOptions & topic_options)
   {
-    const std::string & topic = topic_bridge.topic_name;
+    // Validate topic name
+    const std::string & topic = rclcpp::expand_topic_or_service_name(
+      topic_bridge.topic_name, options_.name(), "/");
+
     const std::string & type = topic_bridge.type_name;
     const std::size_t & from_domain_id = topic_bridge.from_domain_id;
     const std::size_t & to_domain_id = topic_bridge.to_domain_id;
+
+    // Validate type name by loading library support (if not already loaded)
+    // Front-loading let's us fail early on invalid type names
+    load_typesupport_library(type);
 
     // Check if already bridged
     if (bridged_topics_.find(topic_bridge) != bridged_topics_.end()) {
@@ -214,28 +280,38 @@ public:
       return;
     }
 
+    // Create a null entry to avoid duplicate bridges
+    bridged_topics_[topic_bridge] = {nullptr, nullptr};
+
     rclcpp::Node::SharedPtr from_domain_node = get_node_for_domain(from_domain_id);
     rclcpp::Node::SharedPtr to_domain_node = get_node_for_domain(to_domain_id);
 
-    // Determine QoS to use for bridge
-    rclcpp::QoS qos = get_topic_qos(topic, from_domain_node);
+    // Register a callback to be triggered when QoS settings are available for one or more
+    // publishers on the 'from' side of the bridge
+    // The callback may be triggered immediately if a publisher is available
+    auto create_bridge = [ = ](const rclcpp::QoS & qos)
+      {
+        // Get typesupport handle
+        auto typesupport_handle = rosbag2_cpp::get_typesupport_handle(
+          type, "rosidl_typesupport_cpp", loaded_typesupports_[type]);
 
-    // Get typesupport
-    auto typesupport_library = rosbag2_cpp::get_typesupport_library(
-      type, "rosidl_typesupport_cpp");
-    auto typesupport_handle = rosbag2_cpp::get_typesupport_handle(
-      type, "rosidl_typesupport_cpp", typesupport_library);
+        // Create publisher for the 'to_domain'
+        // The publisher should be created first so it is available to the subscription callback
+        auto publisher = this->create_publisher(
+          to_domain_node, topic, qos, *typesupport_handle, topic_options.callback_group());
 
-    // Create publisher for the 'to_domain'
-    // The publisher should be created first so it is available to the subscription callback
-    auto publisher = this->create_publisher(
-      to_domain_node, topic, qos, *typesupport_handle, options.callback_group());
+        // Create subscription for the 'from_domain'
+        auto subscription = this->create_subscription(
+          from_domain_node,
+          publisher,
+          topic,
+          qos,
+          *typesupport_handle,
+          topic_options.callback_group());
 
-    // Create subscription for the 'from_domain'
-    auto subscription = this->create_subscription(
-      from_domain_node, publisher, topic, qos, *typesupport_handle, options.callback_group());
-
-    bridged_topics_[topic_bridge] = {publisher, subscription};
+        this->bridged_topics_[topic_bridge] = {publisher, subscription};
+      };
+    register_on_publisher_qos_ready_callback(topic, from_domain_node, create_bridge);
   }
 
   void add_to_executor(rclcpp::Executor & executor)
@@ -261,6 +337,15 @@ public:
 
   /// Set of bridged topics
   TopicBridgeMap bridged_topics_;
+
+  // Cache of typesupport libraries
+  TypesupportMap loaded_typesupports_;
+
+  /// Threads used for waiting on publishers to become available
+  std::vector<std::shared_ptr<std::thread>> waiting_threads_;
+
+  /// Flag to tell waiting threads we're shutting down
+  std::atomic_bool shutting_down_{false};
 };  // class DomainBridgeImpl
 
 DomainBridge::DomainBridge(const DomainBridgeOptions & options)

--- a/src/domain_bridge/domain_bridge.cpp
+++ b/src/domain_bridge/domain_bridge.cpp
@@ -179,8 +179,12 @@ public:
     // Register a callback to be triggered when QoS settings are available for one or more
     // publishers on the 'from' side of the bridge
     // The callback may be triggered immediately if a publisher is available
-    auto create_bridge = [ = ](const QosMatchInfo & qos_match)
+    auto create_bridge =
+      [this, topic, topic_bridge, topic_options, from_domain_node, to_domain_node]
+        (const QosMatchInfo & qos_match)
       {
+        const std::string & type = topic_bridge.type_name;
+
         // Print any match warnings
         for (const auto & warning : qos_match.warnings) {
           std::cerr << warning << std::endl;

--- a/src/domain_bridge/wait_for_qos_handler.hpp
+++ b/src/domain_bridge/wait_for_qos_handler.hpp
@@ -1,0 +1,201 @@
+// Copyright 2021, Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DOMAIN_BRIDGE__WAIT_FOR_QOS_HANDLER_HPP_
+#define DOMAIN_BRIDGE__WAIT_FOR_QOS_HANDLER_HPP_
+
+// Silly cpplint thinks this is a C system header
+#include <optional>
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "rclcpp/node.hpp"
+#include "rclcpp/qos.hpp"
+
+namespace domain_bridge
+{
+
+/// QoS match information.
+/**
+ * Used as a return value for QoS matching functions.
+ */
+struct QosMatchInfo
+{
+  explicit QosMatchInfo(const rclcpp::QoS & init_qos)
+  : qos(init_qos)
+  {}
+
+  /// A matching QoS
+  rclcpp::QoS qos;
+
+  /// Any warning messages about the matching QoS
+  std::vector<std::string> warnings;
+};
+
+/// Listens for publishers on the ROS graph and provides best matching QoS for them.
+/**
+ * To start listening on a particular topic, register a callback with
+ * `register_on_publisher_qos_ready_callback()`.
+ * The registered callback will be called when one or more publishers are available.
+ * The callback is automatically unregistered after it is called once, or when this class
+ * object is destroyed.
+ *
+ * This is a RAII class.
+ */
+class WaitForQosHandler
+{
+public:
+  WaitForQosHandler() = default;
+
+  ~WaitForQosHandler()
+  {
+    shutting_down_.store(true);
+    for (const auto & t : waiting_threads_) {
+      t->join();
+    }
+  }
+
+  /// Deleted copy constructor.
+  explicit WaitForQosHandler(const DomainBridgeOptions & other) = delete;
+
+  /// Deleted assignment operator.
+  WaitForQosHandler &
+  operator=(const WaitForQosHandler & other) = delete;
+
+  /// Register a callback that is called when QoS is ready for one or more publishers.
+  /**
+   * \param topic: The name of the topic to monitor.
+   * \param node: The node to use to monitor the topic.
+   * \param callback: User callback that is triggered when QoS settings can be determined
+   *   for the provided topic name.
+   *   If QoS settings are already available, then the callback is called immediately.
+   */
+  void register_on_publisher_qos_ready_callback(
+    std::string topic,
+    rclcpp::Node::SharedPtr node,
+    std::function<void(const QosMatchInfo)> callback)
+  {
+    // If the QoS is already avaiable, trigger the callback immediately
+    auto opt_qos = this->get_topic_qos(topic, node);
+    if (opt_qos) {
+      const QosMatchInfo & qos = opt_qos.value();
+      callback(qos);
+      return;
+    }
+
+    // Create a thread that waits for a publisher to become available
+    auto invoke_callback_when_qos_ready = [this, topic, node, callback]()
+      {
+        while (!this->shutting_down_.load()) {
+          // TODO(jacobperron): Use graph events
+          auto opt_qos = this->get_topic_qos(topic, node);
+          if (opt_qos) {
+            const QosMatchInfo & qos = opt_qos.value();
+            callback(qos);
+            return;
+          }
+          std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+      };
+    auto waiting_thread = std::make_shared<std::thread>(invoke_callback_when_qos_ready);
+    waiting_threads_.push_back(waiting_thread);
+  }
+
+private:
+  /// Get QoS settings that best match all available publishers.
+  /**
+   * Queries QoS of existing publishers and returns QoS that is compatibile
+   * with the majority of publishers.
+   * If possible, the returned QoS will exactly match those of the publishers.
+   *
+   * If the existing publishers do not have matching QoS settings, then a warning is set in the
+   * return struct.
+   *
+   * If there are no publishers, then no QoS is returned (i.e. the optional object is not set).
+   */
+  std::optional<QosMatchInfo> get_topic_qos(std::string topic, rclcpp::Node::SharedPtr node)
+  {
+    // TODO(jacobperron): replace this with common implementation when it is available.
+    //       See: https://github.com/ros2/rosbag2/issues/601
+
+    // This implementation is inspired by rosbag2_transport:
+    // https://github.com/ros2/rosbag2/blob/master/rosbag2_transport/src/rosbag2_transport/qos.cpp
+
+    // Query QoS info for publishers
+    std::vector<rclcpp::TopicEndpointInfo> endpoint_info_vec =
+      node->get_publishers_info_by_topic(topic);
+    std::size_t num_endpoints = endpoint_info_vec.size();
+
+    // If there are no publishers, return default QoS
+    if (num_endpoints < 1u) {
+      return {};
+    }
+
+    // Initialize QoS arbitrarily
+    QosMatchInfo result_qos(endpoint_info_vec[0].qos_profile());
+
+    // Reliability and durability policies can cause trouble with enpoint matching
+    // Count number of "reliable" publishers and number of "transient local" publishers
+    std::size_t reliable_count = 0u;
+    std::size_t transient_local_count = 0u;
+    for (const auto & info : endpoint_info_vec) {
+      const auto & profile = info.qos_profile().get_rmw_qos_profile();
+      if (profile.reliability == RMW_QOS_POLICY_RELIABILITY_RELIABLE) {
+        reliable_count++;
+      }
+      if (profile.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL) {
+        transient_local_count++;
+      }
+    }
+
+    // If not all publishers have a "reliable" policy, then use a "best effort" policy
+    // and print a warning
+    if (reliable_count > 0u && reliable_count != num_endpoints) {
+      result_qos.qos.best_effort();
+      std::string warning = "Some, but not all, publishers on topic '" + topic +
+        "' on domain ID " + std::to_string(node->get_node_options().context()->get_domain_id()) +
+        " offer 'reliable' reliability. Falling back to 'best effort' reliability in order "
+        "to connect to all publishers.";
+      result_qos.warnings.push_back(warning);
+    }
+
+    // If not all publishers have a "transient local" policy, then use a "volatile" policy
+    // and print a warning
+    if (transient_local_count > 0u && transient_local_count != num_endpoints) {
+      result_qos.qos.durability_volatile();
+      std::string warning = "Some, but not all, publishers on topic '" + topic +
+        "' on domain ID " + std::to_string(node->get_node_options().context()->get_domain_id()) +
+        " offer 'transient local' durability. Falling back to 'volatile' durability in order "
+        "to connect to all publishers.";
+      result_qos.warnings.push_back(warning);
+    }
+
+    return result_qos;
+  }
+
+  /// Flag to tell waiting threads we're shutting down
+  std::atomic_bool shutting_down_{false};
+
+  /// Threads used for waiting on publishers to become available
+  std::vector<std::shared_ptr<std::thread>> waiting_threads_;
+};  // class WaitForQosHandler
+
+}  // namespace domain_bridge
+
+#endif  // DOMAIN_BRIDGE__WAIT_FOR_QOS_HANDLER_HPP_

--- a/src/domain_bridge/wait_for_qos_handler.hpp
+++ b/src/domain_bridge/wait_for_qos_handler.hpp
@@ -166,7 +166,7 @@ public:
             // or we're shutting down
             cv->wait(
               lock,
-              [this, &topic_callback_vec, event]
+              [this, &topic_callback_vec]
               {return (topic_callback_vec.size() > 0u) || this->shutting_down_;});
           }
         }

--- a/src/domain_bridge/wait_for_qos_handler.hpp
+++ b/src/domain_bridge/wait_for_qos_handler.hpp
@@ -147,7 +147,7 @@ private:
       node->get_publishers_info_by_topic(topic);
     std::size_t num_endpoints = endpoint_info_vec.size();
 
-    // If there are no publishers, return default QoS
+    // If there are no publishers, return an empty optional
     if (num_endpoints < 1u) {
       return {};
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,17 @@ if(TARGET test_domain_bridge_from_yaml)
   target_link_libraries(test_domain_bridge_from_yaml ${PROJECT_NAME})
 endif()
 
+ament_add_gmock(test_qos_matching
+  domain_bridge/test_qos_matching.cpp
+)
+if(TARGET test_qos_matching)
+  ament_target_dependencies(test_qos_matching
+    "rclcpp"
+    "test_msgs"
+  )
+  target_link_libraries(test_qos_matching ${PROJECT_NAME})
+endif()
+
 # Install test files to build directory
 install(
   DIRECTORY "domain_bridge/config"

--- a/test/domain_bridge/test_domain_bridge.cpp
+++ b/test/domain_bridge/test_domain_bridge.cpp
@@ -137,7 +137,7 @@ TEST_F(TestDomainBridge, bridge_topic_invalid)
     EXPECT_THAT(
       stderr_output,
       ::testing::HasSubstr(
-        "Topic 'foo' with type 'test_msgs/msg/BasicTypes' already bridged from "
+        "Topic '/foo' with type 'test_msgs/msg/BasicTypes' already bridged from "
         "domain 1 to domain 2, ignoring\n"));
   }
   // Same bridge twice, following another bridge
@@ -152,7 +152,7 @@ TEST_F(TestDomainBridge, bridge_topic_invalid)
     EXPECT_THAT(
       stderr_output,
       ::testing::HasSubstr(
-        "Topic 'foo' with type 'test_msgs/msg/BasicTypes' already bridged from "
+        "Topic '/foo' with type 'test_msgs/msg/BasicTypes' already bridged from "
         "domain 1 to domain 2, ignoring\n"));
   }
 }

--- a/test/domain_bridge/test_qos_matching.cpp
+++ b/test/domain_bridge/test_qos_matching.cpp
@@ -1,0 +1,130 @@
+// Copyright 2021, Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/context.hpp"
+#include "rclcpp/node.hpp"
+// #include "rclcpp/executors/single_threaded_executor.hpp"
+#include "test_msgs/msg/basic_types.hpp"
+
+#include "domain_bridge/domain_bridge.hpp"
+
+/// Wait for a publisher to be available (or not)
+/*
+ * \return true if the wait was successful, false if a timeout occured.
+ */
+bool wait_for_publisher(
+  std::shared_ptr<rclcpp::Node> node,
+  const std::string & topic_name,
+  bool to_be_available = true,
+  std::chrono::nanoseconds timeout = std::chrono::seconds(3),
+  std::chrono::nanoseconds sleep_period = std::chrono::milliseconds(100))
+{
+  auto start = std::chrono::steady_clock::now();
+  std::chrono::microseconds time_slept(0);
+  auto predicate = [&node, &topic_name, &to_be_available]() -> bool {
+      if (to_be_available) {
+        // A publisher is available if the count is greater than 0
+        return node->count_publishers(topic_name) > 0;
+      } else {
+        return node->count_publishers(topic_name) == 0;
+      }
+    };
+
+  while (!predicate() &&
+    time_slept < std::chrono::duration_cast<std::chrono::microseconds>(timeout))
+  {
+    rclcpp::Event::SharedPtr graph_event = node->get_graph_event();
+    node->wait_for_graph_change(graph_event, sleep_period);
+    time_slept = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - start);
+  }
+  return predicate();
+}
+
+class TestDomainBridgeQosMatching : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    // Initialize contexts in different domains
+    context_1_ = std::make_shared<rclcpp::Context>();
+    rclcpp::InitOptions context_options_1;
+    context_options_1.auto_initialize_logging(false).set_domain_id(domain_1_);
+    context_1_->init(0, nullptr, context_options_1);
+
+    context_2_ = std::make_shared<rclcpp::Context>();
+    rclcpp::InitOptions context_options_2;
+    context_options_2.auto_initialize_logging(false).set_domain_id(domain_2_);
+    context_2_->init(0, nullptr, context_options_2);
+
+    node_options_1_.context(context_1_);
+    node_options_2_.context(context_2_);
+  }
+
+  static const std::size_t domain_1_{1u};
+  static const std::size_t domain_2_{2u};
+  static std::shared_ptr<rclcpp::Context> context_1_;
+  static std::shared_ptr<rclcpp::Context> context_2_;
+  static rclcpp::NodeOptions node_options_1_;
+  static rclcpp::NodeOptions node_options_2_;
+};
+
+const std::size_t TestDomainBridgeQosMatching::domain_1_;
+const std::size_t TestDomainBridgeQosMatching::domain_2_;
+std::shared_ptr<rclcpp::Context> TestDomainBridgeQosMatching::context_1_;
+std::shared_ptr<rclcpp::Context> TestDomainBridgeQosMatching::context_2_;
+rclcpp::NodeOptions TestDomainBridgeQosMatching::node_options_1_;
+rclcpp::NodeOptions TestDomainBridgeQosMatching::node_options_2_;
+
+TEST_F(TestDomainBridgeQosMatching, qos_matches_topic_exists_before_bridge)
+{
+  const std::string topic_name("test_topic_exists_before_bridge");
+
+  // Create a publisher on domain 1
+  auto node_1 = std::make_shared<rclcpp::Node>(
+    "test_topic_exists_before_bridge_node_1", node_options_1_);
+  rclcpp::QoS qos(1);
+  qos.best_effort()
+  .transient_local()
+  .deadline(rclcpp::Duration(123, 456u))
+  .lifespan(rclcpp::Duration(554, 321u))
+  .liveliness(rclcpp::LivelinessPolicy::Automatic);
+  auto pub = node_1->create_publisher<test_msgs::msg::BasicTypes>(topic_name, qos);
+
+  // Bridge the publisher topic to domain 2
+  domain_bridge::DomainBridge bridge;
+  bridge.bridge_topic(topic_name, "test_msgs/msg/BasicTypes", domain_1_, domain_2_);
+
+  // Wait for bridge publisher to appear on domain 2
+  auto node_2 = std::make_shared<rclcpp::Node>(
+    "test_topic_exists_before_bridge_node_2", node_options_2_);
+  ASSERT_TRUE(wait_for_publisher(node_2, topic_name));
+
+  // Assert the QoS of the bridged publisher matches
+  std::vector<rclcpp::TopicEndpointInfo> endpoint_info_vec =
+    node_2->get_publishers_info_by_topic(topic_name);
+  ASSERT_EQ(endpoint_info_vec.size(), 1u);
+  const rclcpp::QoS & bridged_qos = endpoint_info_vec[0].qos_profile();
+  EXPECT_EQ(bridged_qos.reliability(), qos.reliability());
+  EXPECT_EQ(bridged_qos.durability(), qos.durability());
+  EXPECT_EQ(bridged_qos.liveliness(), qos.liveliness());
+  EXPECT_EQ(bridged_qos.deadline(), qos.deadline());
+  EXPECT_EQ(bridged_qos.lifespan(), qos.lifespan());
+}


### PR DESCRIPTION
I've updated the design doc to reflect the implementation.

Specifically, this change introduces a `WaitForQosHandler` class used for deferring topic bridge creation. It creates a thread for each topic bridge to wait for at least one publisher to be available. Once a publisher is available it signals to the domain bridge via a callback, and a topic bridge is created.

In the special case of more than one publisher with different QoS settings, I've adopted a similar approach as rosbag2 for selecting a QoS that is compatible with most of the available publishers. Note, we could factor out this logic following https://github.com/ros2/rosbag2/issues/601 and/or https://github.com/ros2/rmw/issues/304.