### PR TITLE
Add '--from' and '--to' options to executable + add tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,10 @@ install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_exec
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
+install(DIRECTORY examples
+  DESTINATION share/${PROJECT_NAME}
+)
+
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Bridges ROS communication between different ROS domain IDs.
 
 See the [design document](docs/design.md) for more details about how the bridge works.
 
-**NOTE: the following sections are aspirational and are a work-in-progress.**
-
 ## Prerequisites
 
 - [ROS 2](https://index.ros.org/doc/ros2/Installation) (Galactic or newer)
@@ -37,13 +35,28 @@ colcon build
 
 ## Usage
 
-
 ### CLI
 
-There is a standalone executable that can be configured via a YAML file:
+There is a standalone executable that can be configured via a YAML file.
+
+You must provide the path to a YAML configuration file as the last argument to the executable.
+For example,
 
 ```sh
-ros2 run domain_bridge domain_bridge path/to/config.yaml
+ros2 run domain_bridge domain_bridge examples/example_bridge_config.yaml
+```
+
+There are also options to override the domain IDs set for all entities in the YAML config,
+for example,
+
+```sh
+ros2 run domain_bridge domain_bridge --from 7 --to 8 examples/example_bridge_config.yaml
+```
+
+Use the `--help` option for more usage information:
+
+```sh
+ros2 run domain_bridge domain_bridge --help
 ```
 
 ### Launch

--- a/examples/example_bridge_config.yaml
+++ b/examples/example_bridge_config.yaml
@@ -1,0 +1,15 @@
+# Name of the domain bridge, used for node naming and logging
+name: my_bridge
+from_domain: 2
+to_domain: 3
+topics:
+  # Bridge "/clock" topic from doman ID 2 to domain ID 3
+  clock:
+    type: rosgraph_msgs/msg/Clock
+  # Bridge "/chatter" topic from doman ID 2 to domain ID 3
+  chatter:
+    type: example_interfaces/msg/String
+  # Also bridge "/chatter" topic from doman ID 2 to domain ID 4
+  chatter:
+    type: example_interfaces/msg/String
+    to_domain: 4

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,9 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/src/domain_bridge.cpp
+++ b/src/domain_bridge.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdio>
+#include <sstream>
 #include <string>
 
 #include "rclcpp/executors/single_threaded_executor.hpp"
@@ -61,8 +61,9 @@ int main(int argc, char ** argv)
   const char * to_domain_opt = rcutils_cli_get_option(argv, argv + argc, "--to");
   std::size_t from_domain = 0u;
   if (from_domain_opt) {
-    int res = sscanf(from_domain_opt, "%zu", &from_domain);
-    if (res != 1) {
+    std::istringstream iss(from_domain_opt);
+    iss >> from_domain;
+    if (iss.fail() || !iss.eof()) {
       std::cerr << "error: Failed to parse FROM_DOMAIN_ID '" <<
         from_domain_opt << "'" << std::endl;
       return 1;
@@ -70,8 +71,9 @@ int main(int argc, char ** argv)
   }
   std::size_t to_domain = 0u;
   if (to_domain_opt) {
-    int res = sscanf(to_domain_opt, "%zu", &to_domain);
-    if (res != 1) {
+    std::istringstream iss(to_domain_opt);
+    iss >> to_domain;
+    if (iss.fail() || !iss.eof()) {
       std::cerr << "error: Failed to parse TO_DOMAIN_ID '" <<
         to_domain_opt << "'" << std::endl;
       return 1;

--- a/src/domain_bridge.cpp
+++ b/src/domain_bridge.cpp
@@ -12,25 +12,85 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdio>
 #include <string>
 
 #include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rcutils/cmdline_parser.h"
 
 #include "domain_bridge/domain_bridge.hpp"
 #include "domain_bridge/parse_domain_bridge_yaml_config.hpp"
+
+void help()
+{
+  std::cerr << "Usage: domain_bridge "
+    "[--from FROM_DOMAIN_ID] [--to TO_DOMAIN_ID] [-h] YAML_CONFIG" << std::endl <<
+    std::endl <<
+    "Arguments:" << std::endl <<
+    "    YAML_CONFIG    path to a YAML configuration file." << std::endl <<
+    std::endl <<
+    "Options:" << std::endl <<
+    "    --from FROM_DOMAIN_ID    All data will be bridged from this domain ID.  " << std::endl <<
+    "                             This overrides any domain IDs set in the YAML file." <<
+    std::endl <<
+    "    --to TO_DOMAIN_ID        All data will be bridged to this domain ID.  " << std::endl <<
+    "                             This overrides any domain IDs set in the YAML file." <<
+    std::endl <<
+    "    --help, -h               Print this help message." << std::endl;
+}
 
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  if (argc != 2) {
-    std::cerr << "Expected one argument" << std::endl <<
-      "Usage: domain_bridge [YAML_CONFIG]" << std::endl;
+  if (argc < 2) {
+    std::cerr << "error: Expected YAML config file" << std::endl;
+    help();
     return 1;
   }
-  std::string yaml_config = argv[1];
+
+  if (rcutils_cli_option_exist(argv, argv + argc, "-h") ||
+    rcutils_cli_option_exist(argv, argv + argc, "--help"))
+  {
+    help();
+    return 0;
+  }
+
+  // Get options
+  const char * from_domain_opt = rcutils_cli_get_option(argv, argv + argc, "--from");
+  const char * to_domain_opt = rcutils_cli_get_option(argv, argv + argc, "--to");
+  std::size_t from_domain = 0u;
+  if (from_domain_opt) {
+    int res = sscanf(from_domain_opt, "%zu", &from_domain);
+    if (res != 1) {
+      std::cerr << "error: Failed to parse FROM_DOMAIN_ID '" <<
+        from_domain_opt << "'" << std::endl;
+      return 1;
+    }
+  }
+  std::size_t to_domain = 0u;
+  if (to_domain_opt) {
+    int res = sscanf(to_domain_opt, "%zu", &to_domain);
+    if (res != 1) {
+      std::cerr << "error: Failed to parse TO_DOMAIN_ID '" <<
+        to_domain_opt << "'" << std::endl;
+      return 1;
+    }
+  }
+
+  std::string yaml_config = argv[argc - 1];
   domain_bridge::DomainBridgeConfig domain_bridge_config =
     domain_bridge::parse_domain_bridge_yaml_config(yaml_config);
+
+  // Override 'from_domain' and 'to_domain' in config
+  for (auto & topic_option_pair : domain_bridge_config.topics) {
+    if (from_domain_opt) {
+      topic_option_pair.first.from_domain_id = from_domain;
+    }
+    if (to_domain_opt) {
+      topic_option_pair.first.to_domain_id = to_domain;
+    }
+  }
 
   domain_bridge::DomainBridge domain_bridge(domain_bridge_config);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 find_package(ament_cmake_gmock REQUIRED)
 find_package(ament_cmake_gtest REQUIRED)
+find_package(launch_testing_ament_cmake REQUIRED)
 find_package(test_msgs REQUIRED)
 
 ament_add_gmock(test_domain_bridge
@@ -30,6 +31,12 @@ if(TARGET test_qos_matching)
   )
   target_link_libraries(test_qos_matching ${PROJECT_NAME})
 endif()
+
+# Test executable
+add_launch_test(
+  test_domain_bridge.launch.py
+  WORKING_DIRECTORY "$<TARGET_FILE_DIR:${PROJECT_NAME}_exec>"
+)
 
 # Install test files to build directory
 install(

--- a/test/test_domain_bridge.launch.py
+++ b/test/test_domain_bridge.launch.py
@@ -1,0 +1,140 @@
+# Copyright 2021, Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import os
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+import launch_testing
+from launch_testing.actions import ReadyToTest
+import launch_testing.asserts
+import launch_testing.tools
+from launch_testing.util import KeepAliveProc
+
+
+def generate_test_description():
+    return LaunchDescription([
+        KeepAliveProc(),
+        ReadyToTest()
+    ])
+
+
+class TestDomainBridge(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(
+        cls,
+        launch_service,
+        proc_info,
+        proc_output
+    ):
+
+        @contextlib.contextmanager
+        def launch_domain_bridge(self, arguments):
+            executable = os.path.join(os.getcwd(), 'domain_bridge')
+            if os.name == 'nt':
+                executable += '.exe'
+            cmd = [executable] + arguments
+            domain_bridge_proc = ExecuteProcess(
+                cmd=cmd,
+                output='screen',
+            )
+            with launch_testing.tools.launch_process(
+                launch_service, domain_bridge_proc, proc_info, proc_output
+            ) as launch_process:
+                yield launch_process
+
+        cls.launch_domain_bridge = launch_domain_bridge
+
+        cls.example_yaml_path = os.path.join(
+            os.path.dirname(__file__), '..', 'examples', 'example_bridge_config.yaml')
+
+    def test_help(self):
+        with self.launch_domain_bridge(arguments=['--help']) as command:
+            assert command.wait_for_shutdown(timeout=3)
+        assert command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                '    --help, -h               Print this help message.',
+            ],
+            text=command.output,
+            strict=False
+        )
+
+    def test_bridge_invalid_file(self):
+        path_to_yaml = 'file_should_NOT_exist'
+        with self.launch_domain_bridge(arguments=[path_to_yaml]) as command:
+            assert command.wait_for_shutdown(timeout=3)
+        assert command.exit_code != launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                "  what():  error parsing the file 'file_should_NOT_exist': file does not exist",
+            ],
+            text=command.output,
+            strict=False
+        )
+
+    def test_bridge_valid_file(self, proc_info):
+        with self.launch_domain_bridge(arguments=[self.example_yaml_path]) as command:
+            # Let command run for a bit
+            time.sleep(1)
+        proc_info.assertWaitForShutdown(process=command.target_process_action, timeout=3)
+        assert command.exit_code == launch_testing.asserts.EXIT_OK
+
+    def test_bridge_valid_from_domain(self, proc_info):
+        with self.launch_domain_bridge(
+            arguments=['--from', '42', self.example_yaml_path]
+        ) as command:
+            # Let command run for a bit
+            time.sleep(1)
+        proc_info.assertWaitForShutdown(process=command.target_process_action, timeout=3)
+        assert command.exit_code == launch_testing.asserts.EXIT_OK
+
+    def test_bridge_valid_to_domain(self, proc_info):
+        with self.launch_domain_bridge(arguments=['--to', '0', self.example_yaml_path]) as command:
+            # Let command run for a bit
+            time.sleep(1)
+        proc_info.assertWaitForShutdown(process=command.target_process_action, timeout=3)
+        assert command.exit_code == launch_testing.asserts.EXIT_OK
+
+    def test_bridge_invalid_from_domain(self, proc_info):
+        with self.launch_domain_bridge(
+            arguments=['--from', '.42', self.example_yaml_path]
+        ) as command:
+            assert command.wait_for_shutdown(timeout=3)
+        assert command.exit_code != launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                "error: Failed to parse FROM_DOMAIN_ID '.42'",
+            ],
+            text=command.output,
+            strict=False
+        )
+
+    def test_bridge_invalid_to_domain(self, proc_info):
+        with self.launch_domain_bridge(
+            arguments=['--to', 'not_a_num', self.example_yaml_path]
+        ) as command:
+            assert command.wait_for_shutdown(timeout=3)
+        assert command.exit_code != launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                "error: Failed to parse TO_DOMAIN_ID 'not_a_num'",
+            ],
+            text=command.output,
+            strict=False
+        )

--- a/test/test_domain_bridge.launch.py
+++ b/test/test_domain_bridge.launch.py
@@ -113,13 +113,13 @@ class TestDomainBridge(unittest.TestCase):
 
     def test_bridge_invalid_from_domain(self, proc_info):
         with self.launch_domain_bridge(
-            arguments=['--from', '.42', self.example_yaml_path]
+            arguments=['--from', '42.0', self.example_yaml_path]
         ) as command:
             assert command.wait_for_shutdown(timeout=3)
         assert command.exit_code != launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
             expected_lines=[
-                "error: Failed to parse FROM_DOMAIN_ID '.42'",
+                "error: Failed to parse FROM_DOMAIN_ID '42.0'",
             ],
             text=command.output,
             strict=False


### PR DESCRIPTION
- Add options for overriding 'from' and 'to' domain IDs from the CLI (7e14198)
- Add launch tests for executable (2d2171e)
- Add example config (also validated by tests) (3902e3d)
- Updated README (9cfc223)

Depends on https://github.com/ros2/domain_bridge/pull/6