### PR TITLE
Change default value of deadline and lifespan

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -126,15 +126,16 @@ The solution is to have the bridge wait until a publisher becomes available befo
 #### Deadline
 
 Due to possible delays induced by the bridge, it is possible that the original deadline of a publisher may not be met when forwarding to a different domain.
-Furthermore, if deadline is important for the user application, then it is probably better for them to set manually on the bridge.
-Therefore, by default the bridge will assume the RMW defined default value for deadline (typically implying "no deadline"), but allow users to opt-in to matching the publisher value or setting the value manually.
+If a deadline is important for the user application, then it should be set manually on the bridge.
+Therefore, by default, the bridge will use the RMW-defined default value for deadline (typically implying "no deadline").
+Users may set the value manually or configure the bridge to use the original publishers value.
 
 #### Lifespan
 
 The lifespan policy is closely coupled with the history policy.
 Since the bridge is not able to automatically detect the history policy of publishers, it is safer to let the user configure lifespan given their application-specific knowledge.
-For similar reasons as the deadline policy, by default the bridge will assume the RMW defined default value for the lifespan policy.
-Likewise, users can opt-in to matching the publisher value or setting the value manually.
+For similar reasons as the deadline policy, by default the bridge will use the RMW-defined default value for the lifespan policy.
+Likewise, users can set the value manually or configure the bridge to use the original publishers value.
 
 #### Liveliness
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -127,13 +127,13 @@ The solution is to have the bridge wait until a publisher becomes available befo
 
 Due to possible delays induced by the bridge, it is possible that the original deadline of a publisher may not be met when forwarding to a different domain.
 Furthermore, if deadline is important for the user application, then it is probably better for them to set manually on the bridge.
-Therefore, by default the bridge will assume a maximum value for deadline, but allow users to opt-in to matching the publisher value or setting the value manually.
+Therefore, by default the bridge will assume the RMW defined default value for deadline (typically implying "no deadline"), but allow users to opt-in to matching the publisher value or setting the value manually.
 
 #### Lifespan
 
 The lifespan policy is closely coupled with the history policy.
 Since the bridge is not able to automatically detect the history policy of publishers, it is safer to let the user configure lifespan given their application-specific knowledge.
-For similar reasons as the deadline policy, by default the bridge will assume a maximum value for the lifespan policy.
+For similar reasons as the deadline policy, by default the bridge will assume the RMW defined default value for the lifespan policy.
 Likewise, users can opt-in to matching the publisher value or setting the value manually.
 
 #### Liveliness

--- a/doc/design.md
+++ b/doc/design.md
@@ -128,26 +128,26 @@ The solution is to have the bridge wait until a publisher becomes available befo
 Due to possible delays induced by the bridge, it is possible that the original deadline of a publisher may not be met when forwarding to a different domain.
 If a deadline is important for the user application, then it should be set manually on the bridge.
 Therefore, by default, the bridge will use the RMW-defined default value for deadline (typically implying "no deadline").
-Users may set the value manually or configure the bridge to use the original publishers value.
+Users may set the value manually or configure the bridge to use the original publisher's value.
 
 #### Lifespan
 
 The lifespan policy is closely coupled with the history policy.
 Since the bridge is not able to automatically detect the history policy of publishers, it is safer to let the user configure lifespan given their application-specific knowledge.
 For similar reasons as the deadline policy, by default the bridge will use the RMW-defined default value for the lifespan policy.
-Likewise, users can set the value manually or configure the bridge to use the original publishers value.
+Likewise, users can set the value manually or configure the bridge to use the original publisher's value.
 
 #### Liveliness
 
 The liveliness QoS policy can either be set to "automatic" or "manual by topic".
-If it is "automatic", the system will use the published messages as a heartbeat to consider if the publishers node is alive.
+If it is "automatic", the system will use the published messages as a heartbeat to consider if the publisher's node is alive.
 If it is "manual by topic", the node needs to manually call a publisher API to assert it is alive.
 
 This poses a problem for the domain bridge.
 If the liveliness of a publisher is "manual by topic", then the bridge cannot mimic the QoS behavior into another domain.
 It would require the bridge to know when the original publisher is asserting its liveliness (i.e. calling the publisher API).
 Since there is no mechanism in ROS 2 to get this information at the subscription site, the bridge cannot support "manual by topic" liveliness.
-Therefore, the bridge will always use "automatic" liveliness, regardless of the original publishers policy.
+Therefore, the bridge will always use "automatic" liveliness, regardless of the original publisher's policy.
 
 #### Multiple publishers
 

--- a/include/domain_bridge/qos_options.hpp
+++ b/include/domain_bridge/qos_options.hpp
@@ -36,8 +36,8 @@ public:
    *    - durability = nullopt_t (detect automatically)
    *    - history = rclcpp::HistoryPolicy::KeepLast
    *    - depth = 10
-   *    - deadline = -1 (infinite)
-   *    - lifespan = -1 (infinite)
+   *    - deadline = 0 (RMW default)
+   *    - lifespan = 0 (RMW default)
    */
   DOMAIN_BRIDGE_PUBLIC
   QosOptions() = default;
@@ -107,6 +107,7 @@ public:
   /// Set deadline.
   /**
    * \param deadline: number of nanoseconds.
+   *   If zero, then use the RMW default policy.
    *   If negative, then it is treated an "infinite" (max number of nanoseconds).
    */
   DOMAIN_BRIDGE_PUBLIC
@@ -129,6 +130,7 @@ public:
   /// Set lifespan in nanoseconds.
   /**
    * \param lifespan: number of nanoseconds.
+   *   If zero, then use the RMW default policy.
    *   If negative, then it is treated an "infinite" (max number of nanoseconds).
    */
   DOMAIN_BRIDGE_PUBLIC
@@ -145,8 +147,8 @@ private:
   std::optional<rclcpp::DurabilityPolicy> durability_;
   rclcpp::HistoryPolicy history_{rclcpp::HistoryPolicy::KeepLast};
   std::size_t depth_{10};
-  std::optional<std::int64_t> deadline_{-1};
-  std::optional<std::int64_t> lifespan_{-1};
+  std::optional<std::int64_t> deadline_{0};
+  std::optional<std::int64_t> lifespan_{0};
 };  // class QosOptions
 
 }  // namespace domain_bridge


### PR DESCRIPTION
Default to the RMW default value.
This fixes an issue with Connext, which does not handle the same maximum
value as other RMWs.

Fixes https://github.com/ros2/domain_bridge/issues/14