### PR TITLE
Add explicit link against stdc++fs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,10 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 
+if(CMAKE_COMPILER_IS_GNUCXX)
+  target_link_libraries(${PROJECT_NAME} stdc++fs)
+endif()
+
 ament_target_dependencies(${PROJECT_NAME}
   rclcpp
   rcutils


### PR DESCRIPTION
It seems that this may not be necessary with GCC 9, but stdc++fs isn't part of libstdc++ prior to that.

Should unblock RHEL builds: https://build.ros2.org/job/Rbin_rhel_el864__domain_bridge__rhel_8_x86_64__binary/4/console

Is there any CI I should trigger for this change?