### PR TITLE
Stop installing test resources

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,9 +37,3 @@ add_launch_test(
   test_domain_bridge.launch.py
   WORKING_DIRECTORY "$<TARGET_FILE_DIR:${PROJECT_NAME}_exec>"
 )
-
-# Install test files to build directory
-install(
-  DIRECTORY "domain_bridge/config"
-  DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
-)


### PR DESCRIPTION
During colcon builds, colcon is using the CMAKE_INSTALL_PREFIX to dictate where the files should be installed to. During Debian and RPM builds, the DESTDIR environment variable is used. The latter approach prefixes all of the install paths, including absolute paths like the destination for the test test resource installation.

The end result is that they get installed into the staging directory for the platform package, and typically end up in the package at some unexpected location.

For RPM builds, this is a fatal build failure, as ROS packages are not expected to install anything outside of /opt/ros/<foo>.

It doesn't appear that installing these resources is even necessary because the working directory of the test means that they're already available to the test that needs them without copying.

You can see these extra files if you list the contents of the deb:
```
$ dpkg-query -L ros-rolling-domain-bridge
/.
/opt
/opt/ros
/opt/ros/rolling
/opt/ros/rolling/include
/opt/ros/rolling/include/domain_bridge

...

/tmp
/tmp/binarydeb
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test/config
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test/config/default_domain_ids.yaml
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test/config/empty.yaml
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test/config/invalid_depth.yaml
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test/config/invalid_durability.yaml
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test/config/invalid_history.yaml
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test/config/invalid_reliability.yaml
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test/config/missing_from_domain.yaml
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test/config/missing_to_domain.yaml
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test/config/missing_type.yaml
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test/config/name.yaml
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test/config/qos_as_list.yaml
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test/config/topic_options.yaml
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test/config/topics.yaml
/tmp/binarydeb/ros-rolling-domain-bridge-0.1.0/obj-x86_64-linux-gnu/test/config/topics_as_list.yaml
/usr
/usr/share
/usr/share/doc
/usr/share/doc/ros-rolling-domain-bridge
/usr/share/doc/ros-rolling-domain-bridge/changelog.Debian.gz
```