### PR TITLE
Do not crash if there's an error querying endpoint info

### DIFF
--- a/src/domain_bridge/wait_for_qos_handler.hpp
+++ b/src/domain_bridge/wait_for_qos_handler.hpp
@@ -152,7 +152,10 @@ public:
                 if (!context->is_valid()) {
                   return;
                 }
-                throw ex;
+                // Otherwise, don't crash if there was a hiccup querying the topic endpoint
+                // Log an error instead
+                std::cerr << "Failed to query info for topic '" << topic << "': " << ex.what() <<
+                  std::endl;
               }
 
               if (opt_qos) {


### PR DESCRIPTION
I've observed in larger systems sometimes the RMW layer will return an error when trying to query publisher info.
If this happens, rclcpp throws an RCLError exception and the domain bridge crashes. I have not been able to
reliable reproduce this exception, but it seems to happen during the discovery phase. I've only observed it using rmw_connext_cpp.

In any case, it seems reasonable to log an error instead of throwing an exception so that the domain bridge threads can keep working.