### PR TITLE
Override handle_serialized_message.

### DIFF
--- a/src/domain_bridge/generic_subscription.cpp
+++ b/src/domain_bridge/generic_subscription.cpp
@@ -79,6 +79,14 @@ void GenericSubscription::handle_loaned_message(
   (void) message_info;
 }
 
+void GenericSubscription::handle_serialized_message(
+  const std::shared_ptr<rclcpp::SerializedMessage> & serialized_message,
+  const rclcpp::MessageInfo & message_info)
+{
+  (void) serialized_message;
+  (void) message_info;
+}
+
 void GenericSubscription::return_message(std::shared_ptr<void> & message)
 {
   auto typed_message = std::static_pointer_cast<rclcpp::SerializedMessage>(message);

--- a/src/domain_bridge/generic_subscription.hpp
+++ b/src/domain_bridge/generic_subscription.hpp
@@ -69,6 +69,11 @@ public:
   void handle_loaned_message(
     void * loaned_message, const rclcpp::MessageInfo & message_info) override;
 
+  void
+  handle_serialized_message(
+    const std::shared_ptr<rclcpp::SerializedMessage> & serialized_message,
+    const rclcpp::MessageInfo & message_info) override;
+
   // Same as return_serialized_message() as the subscription is to serialized_messages only
   void return_message(std::shared_ptr<void> & message) override;
 

--- a/src/domain_bridge/generic_subscription.hpp
+++ b/src/domain_bridge/generic_subscription.hpp
@@ -69,10 +69,14 @@ public:
   void handle_loaned_message(
     void * loaned_message, const rclcpp::MessageInfo & message_info) override;
 
+  // Post-Galactic, handle_serialized_message is a pure virtual function in
+  // rclcpp::SubscriptionBase, so we must override it.  However, in order to
+  // make this change compatible with both Galactic and later, we leave off
+  // the 'override' flag.
   void
   handle_serialized_message(
     const std::shared_ptr<rclcpp::SerializedMessage> & serialized_message,
-    const rclcpp::MessageInfo & message_info) override;
+    const rclcpp::MessageInfo & message_info);
 
   // Same as return_serialized_message() as the subscription is to serialized_messages only
   void return_message(std::shared_ptr<void> & message) override;


### PR DESCRIPTION
This should allow it to build against rolling again.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This has been failing in Rolling for a couple of weeks now: https://build.ros2.org/view/Rbin_uF64/job/Rbin_uF64__domain_bridge__ubuntu_focal_amd64__binary/

Note that this change is *not* backwards-compatible with Galactic, so we'll have to branch off for Galactic to take this fix.