### PR TITLE
Reintroduce compatibility with galactic

### DIFF
--- a/src/domain_bridge/generic_subscription.cpp
+++ b/src/domain_bridge/generic_subscription.cpp
@@ -67,9 +67,9 @@ std::shared_ptr<rclcpp::SerializedMessage> GenericSubscription::create_serialize
 void GenericSubscription::handle_message(
   std::shared_ptr<void> & message, const rclcpp::MessageInfo & message_info)
 {
-  (void) message;
   (void) message_info;
-  throw std::runtime_error{"unexpected callback being called"};
+  auto typed_message = std::static_pointer_cast<rclcpp::SerializedMessage>(message);
+  callback_(typed_message);
 }
 
 void GenericSubscription::handle_loaned_message(
@@ -85,8 +85,7 @@ void GenericSubscription::handle_serialized_message(
   const rclcpp::MessageInfo & message_info)
 {
   (void)message_info;
-  auto typed_message = std::static_pointer_cast<rclcpp::SerializedMessage>(serialized_message);
-  callback_(typed_message);
+  callback_(serialized_message);
 }
 
 void GenericSubscription::return_message(std::shared_ptr<void> & message)


### PR DESCRIPTION
https://github.com/ros2/domain_bridge/pull/27 broke compatibility with galactic.
This patch should reintroduce it :crossed_fingers: .

Overriding both handle_message() and handle_serialized_message() shouldn't be a problem.