### PR TITLE
Add `--mode` argument to `domain_bridge`

### DIFF
--- a/src/domain_bridge.cpp
+++ b/src/domain_bridge.cpp
@@ -12,12 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstring>
-#include <sstream>
-#include <string>
-
 #include "rclcpp/executors/single_threaded_executor.hpp"
-#include "rcutils/cmdline_parser.h"
 
 #include "domain_bridge/domain_bridge.hpp"
 #include "domain_bridge/parse_domain_bridge_yaml_config.hpp"

--- a/src/domain_bridge.cpp
+++ b/src/domain_bridge.cpp
@@ -39,6 +39,5 @@ int main(int argc, char ** argv)
   executor.spin();
 
   rclcpp::shutdown();
-
   return 0;
 }

--- a/src/domain_bridge.cpp
+++ b/src/domain_bridge.cpp
@@ -22,106 +22,17 @@
 #include "domain_bridge/domain_bridge.hpp"
 #include "domain_bridge/parse_domain_bridge_yaml_config.hpp"
 
-constexpr char kCompressModeStr[] = "compress";
-constexpr char kDecompressModeStr[] = "decompress";
-constexpr char kNormalModeStr[] = "normal";
-
-void help()
-{
-  std::cerr << "Usage: domain_bridge "
-    "[--from FROM_DOMAIN_ID] [--to TO_DOMAIN_ID] [-h] YAML_CONFIG" << std::endl <<
-    std::endl <<
-    "Arguments:" << std::endl <<
-    "    YAML_CONFIG    path to a YAML configuration file." << std::endl <<
-    std::endl <<
-    "Options:" << std::endl <<
-    "    --from FROM_DOMAIN_ID    All data will be bridged from this domain ID.  " << std::endl <<
-    "                             This overrides any domain IDs set in the YAML file." <<
-    std::endl <<
-    "    --to TO_DOMAIN_ID        All data will be bridged to this domain ID.  " << std::endl <<
-    "                             This overrides any domain IDs set in the YAML file." <<
-    std::endl <<
-    "    --mode MODE_STR          Specify the bridge mode, valid values: '" << kCompressModeStr <<
-    "', '" << kDecompressModeStr << "' or '" << kNormalModeStr << "'.  " << std::endl <<
-    "                             This overrides any mode set in the YAML file." << std::endl <<
-    "                             Defaults to '" << kNormalModeStr << "'." <<
-    std::endl <<
-    "    --help, -h               Print this help message." << std::endl;
-}
+#include "process_cmd_line_arguments.hpp"
 
 int main(int argc, char ** argv)
 {
-  rclcpp::init(argc, argv);
+  auto arguments = rclcpp::init_and_remove_ros_arguments(argc, argv);
 
-  if (argc < 2) {
-    std::cerr << "error: Expected YAML config file" << std::endl;
-    help();
-    return 1;
+  auto config_rc_pair = domain_bridge::detail::process_cmd_line_arguments(arguments);
+  if (!config_rc_pair.first || 0 != config_rc_pair.second) {
+    return config_rc_pair.second;
   }
-
-  if (rcutils_cli_option_exist(argv, argv + argc, "-h") ||
-    rcutils_cli_option_exist(argv, argv + argc, "--help"))
-  {
-    help();
-    return 0;
-  }
-
-  // Get options
-  const char * from_domain_opt = rcutils_cli_get_option(argv, argv + argc, "--from");
-  const char * to_domain_opt = rcutils_cli_get_option(argv, argv + argc, "--to");
-  const char * mode_opt = rcutils_cli_get_option(argv, argv + argc, "--mode");
-  std::size_t from_domain = 0u;
-  if (from_domain_opt) {
-    std::istringstream iss(from_domain_opt);
-    iss >> from_domain;
-    if (iss.fail() || !iss.eof()) {
-      std::cerr << "error: Failed to parse FROM_DOMAIN_ID '" <<
-        from_domain_opt << "'" << std::endl;
-      return 1;
-    }
-  }
-  std::size_t to_domain = 0u;
-  if (to_domain_opt) {
-    std::istringstream iss(to_domain_opt);
-    iss >> to_domain;
-    if (iss.fail() || !iss.eof()) {
-      std::cerr << "error: Failed to parse TO_DOMAIN_ID '" <<
-        to_domain_opt << "'" << std::endl;
-      return 1;
-    }
-  }
-  domain_bridge::DomainBridgeOptions::Mode mode = domain_bridge::DomainBridgeOptions::Mode::Normal;
-  if (mode_opt) {
-    if (0 == std::strncmp(mode_opt, kCompressModeStr, sizeof(kCompressModeStr))) {
-      mode = domain_bridge::DomainBridgeOptions::Mode::Compress;
-    } else if (0 == std::strncmp(mode_opt, kDecompressModeStr, sizeof(kDecompressModeStr))) {
-      mode = domain_bridge::DomainBridgeOptions::Mode::Decompress;
-    } else if (0 == std::strncmp(mode_opt, kNormalModeStr, sizeof(kNormalModeStr))) {
-      mode = domain_bridge::DomainBridgeOptions::Mode::Normal;
-    } else {
-      std::cerr << "error: Invalid '--mode' option '" <<
-        mode_opt << "'" << std::endl;
-      return 1;
-    }
-  }
-
-  std::string yaml_config = argv[argc - 1];
-  domain_bridge::DomainBridgeConfig domain_bridge_config =
-    domain_bridge::parse_domain_bridge_yaml_config(yaml_config);
-
-  // Override 'from_domain' and 'to_domain' in config
-  for (auto & topic_option_pair : domain_bridge_config.topics) {
-    if (from_domain_opt) {
-      topic_option_pair.first.from_domain_id = from_domain;
-    }
-    if (to_domain_opt) {
-      topic_option_pair.first.to_domain_id = to_domain;
-    }
-  }
-  if (mode_opt) {
-    domain_bridge_config.options.mode(mode);
-  }
-  domain_bridge::DomainBridge domain_bridge(domain_bridge_config);
+  domain_bridge::DomainBridge domain_bridge(*config_rc_pair.first);
 
   rclcpp::executors::SingleThreadedExecutor executor;
   domain_bridge.add_to_executor(executor);

--- a/src/domain_bridge_rti_qos.cpp
+++ b/src/domain_bridge_rti_qos.cpp
@@ -20,28 +20,12 @@
 #include "rcutils/cmdline_parser.h"
 #include "rcutils/env.h"
 
+#include "ndds/ndds_c.h"
+
 #include "domain_bridge/domain_bridge.hpp"
 #include "domain_bridge/parse_domain_bridge_yaml_config.hpp"
 
-#include "ndds/ndds_c.h"
-
-void help()
-{
-  std::cerr << "Usage: domain_bridge "
-    "[--from FROM_DOMAIN_ID] [--to TO_DOMAIN_ID] [-h] YAML_CONFIG" << std::endl <<
-    std::endl <<
-    "Arguments:" << std::endl <<
-    "    YAML_CONFIG    path to a YAML configuration file." << std::endl <<
-    std::endl <<
-    "Options:" << std::endl <<
-    "    --from FROM_DOMAIN_ID    All data will be bridged from this domain ID.  " << std::endl <<
-    "                             This overrides any domain IDs set in the YAML file." <<
-    std::endl <<
-    "    --to TO_DOMAIN_ID        All data will be bridged to this domain ID.  " << std::endl <<
-    "                             This overrides any domain IDs set in the YAML file." <<
-    std::endl <<
-    "    --help, -h               Print this help message." << std::endl;
-}
+#include "process_cmd_line_arguments.hpp"
 
 bool
 set_default_qos_library(DDS_DomainParticipantFactory * dpf);
@@ -51,58 +35,14 @@ get_domain_profile_prefix();
 
 int main(int argc, char ** argv)
 {
-  rclcpp::init(argc, argv);
+  auto arguments = rclcpp::init_and_remove_ros_arguments(argc, argv);
 
-  if (argc < 2) {
-    std::cerr << "error: Expected YAML config file" << std::endl;
-    help();
-    return 1;
+  auto config_rc_pair = domain_bridge::detail::process_cmd_line_arguments(arguments);
+  if (!config_rc_pair.first || 0 != config_rc_pair.second) {
+    return config_rc_pair.second;
   }
+  auto & domain_bridge_config = *config_rc_pair.first;
 
-  if (rcutils_cli_option_exist(argv, argv + argc, "-h") ||
-    rcutils_cli_option_exist(argv, argv + argc, "--help"))
-  {
-    help();
-    return 0;
-  }
-
-  // Get options
-  const char * from_domain_opt = rcutils_cli_get_option(argv, argv + argc, "--from");
-  const char * to_domain_opt = rcutils_cli_get_option(argv, argv + argc, "--to");
-  std::size_t from_domain = 0u;
-  if (from_domain_opt) {
-    std::istringstream iss(from_domain_opt);
-    iss >> from_domain;
-    if (iss.fail() || !iss.eof()) {
-      std::cerr << "error: Failed to parse FROM_DOMAIN_ID '" <<
-        from_domain_opt << "'" << std::endl;
-      return 1;
-    }
-  }
-  std::size_t to_domain = 0u;
-  if (to_domain_opt) {
-    std::istringstream iss(to_domain_opt);
-    iss >> to_domain;
-    if (iss.fail() || !iss.eof()) {
-      std::cerr << "error: Failed to parse TO_DOMAIN_ID '" <<
-        to_domain_opt << "'" << std::endl;
-      return 1;
-    }
-  }
-
-  std::string yaml_config = argv[argc - 1];
-  domain_bridge::DomainBridgeConfig domain_bridge_config =
-    domain_bridge::parse_domain_bridge_yaml_config(yaml_config);
-
-  // Override 'from_domain' and 'to_domain' in config
-  for (auto & topic_option_pair : domain_bridge_config.topics) {
-    if (from_domain_opt) {
-      topic_option_pair.first.from_domain_id = from_domain;
-    }
-    if (to_domain_opt) {
-      topic_option_pair.first.to_domain_id = to_domain;
-    }
-  }
   DDS_DomainParticipantFactory * dpf = DDS_DomainParticipantFactory_get_instance();
   const char * prefix = get_domain_profile_prefix();
   static DDS_DomainParticipantQos default_dpqos = DDS_DomainParticipantQos_INITIALIZER;

--- a/src/domain_bridge_rti_qos.cpp
+++ b/src/domain_bridge_rti_qos.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <stdexcept>
+#include <string>
+
 #include "rclcpp/executors/single_threaded_executor.hpp"
 #include "rcpputils/scope_exit.hpp"
 #include "rcutils/env.h"

--- a/src/domain_bridge_rti_qos.cpp
+++ b/src/domain_bridge_rti_qos.cpp
@@ -12,12 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <sstream>
-#include <string>
-
 #include "rclcpp/executors/single_threaded_executor.hpp"
 #include "rcpputils/scope_exit.hpp"
-#include "rcutils/cmdline_parser.h"
 #include "rcutils/env.h"
 
 #include "ndds/ndds_c.h"

--- a/src/process_cmd_line_arguments.hpp
+++ b/src/process_cmd_line_arguments.hpp
@@ -133,7 +133,7 @@ process_cmd_line_arguments(const std::vector<std::string> & args)
       continue;
     }
     if (yaml_config) {
-      std::cerr << "error: Can only specified one yaml configuration file '" <<
+      std::cerr << "error: Can only specify one yaml configuration file '" <<
         *it << "'" << std::endl;
       return std::make_pair(std::nullopt, 1);
     }

--- a/src/process_cmd_line_arguments.hpp
+++ b/src/process_cmd_line_arguments.hpp
@@ -1,0 +1,168 @@
+// Copyright 2021, Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PROCESS_CMD_LINE_ARGUMENTS_HPP_
+#define PROCESS_CMD_LINE_ARGUMENTS_HPP_
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "domain_bridge/domain_bridge_config.hpp"
+
+namespace domain_bridge
+{
+namespace detail
+{
+static constexpr char kCompressModeStr[] = "compress";
+static constexpr char kDecompressModeStr[] = "decompress";
+static constexpr char kNormalModeStr[] = "normal";
+
+inline
+void
+print_help()
+{
+  std::cerr << "Usage: domain_bridge "
+    "[--from FROM_DOMAIN_ID] [--to TO_DOMAIN_ID] [-h] YAML_CONFIG" << std::endl <<
+    std::endl <<
+    "Arguments:" << std::endl <<
+    "    YAML_CONFIG    path to a YAML configuration file." << std::endl <<
+    std::endl <<
+    "Options:" << std::endl <<
+    "    --from FROM_DOMAIN_ID    All data will be bridged from this domain ID.  " << std::endl <<
+    "                             This overrides any domain IDs set in the YAML file." <<
+    std::endl <<
+    "    --to TO_DOMAIN_ID        All data will be bridged to this domain ID.  " << std::endl <<
+    "                             This overrides any domain IDs set in the YAML file." <<
+    std::endl <<
+    "    --mode MODE_STR          Specify the bridge mode, valid values: '" << kCompressModeStr <<
+    "', '" << kDecompressModeStr << "' or '" << kNormalModeStr << "'.  " << std::endl <<
+    "                             This overrides any mode set in the YAML file." << std::endl <<
+    "                             Defaults to '" << kNormalModeStr << "'." <<
+    std::endl <<
+    "    --help, -h               Print this help message." << std::endl;
+}
+
+inline
+std::optional<size_t>
+parse_size_t_arg(const std::string & arg, const char * error_str)
+{
+  size_t value;
+  std::istringstream iss(arg);
+  iss >> value;
+  if (iss.fail() || !iss.eof()) {
+    std::cerr << "error: Failed to parse " << error_str << " '" <<
+      arg << "'" << std::endl;
+    return std::nullopt;
+  }
+  return value;
+}
+
+inline
+std::pair<std::optional<DomainBridgeConfig>, int>
+process_cmd_line_arguments(const std::vector<std::string> & args)
+{
+  if (args.size() < 2) {
+    std::cerr << "error: Expected YAML config file" << std::endl;
+    print_help();
+    return std::make_pair(std::nullopt, 1);
+  }
+  std::optional<size_t> from_domain_id;
+  std::optional<size_t> to_domain_id;
+  std::optional<domain_bridge::DomainBridgeOptions::Mode> mode;
+  std::optional<std::string> yaml_config;
+
+  for (auto it = ++args.cbegin() /*skip executable name*/; it != args.cend(); ++it) {
+    const auto & arg = *it;
+    if (arg == "-h" || arg == "--help") {
+      print_help();
+      return std::make_pair(std::nullopt, 0);
+    }
+    if (arg == "--from") {
+      if (from_domain_id) {
+        std::cerr << "error: --from option passed more than once" << std::endl;
+        print_help();
+        return std::make_pair(std::nullopt, 1);
+      }
+      ++it;
+      from_domain_id = parse_size_t_arg(*it, "FROM_DOMAIN_ID");
+      if (!from_domain_id) {
+        return std::make_pair(std::nullopt, 1);
+      }
+      continue;
+    }
+    if (arg == "--to") {
+      if (to_domain_id) {
+        std::cerr << "error: --to option passed more than once" << std::endl;
+        print_help();
+        return std::make_pair(std::nullopt, 1);
+      }
+      ++it;
+      to_domain_id = parse_size_t_arg(*it, "TO_DOMAIN_ID");
+      if (!to_domain_id) {
+        return std::make_pair(std::nullopt, 1);
+      }
+      continue;
+    }
+    if (arg == "--mode") {
+      ++it;
+      const auto & mode_str = *it;
+      if (mode_str == kCompressModeStr) {
+        mode = domain_bridge::DomainBridgeOptions::Mode::Compress;
+      } else if (mode_str == kDecompressModeStr) {
+        mode = domain_bridge::DomainBridgeOptions::Mode::Decompress;
+      } else if (mode_str == kNormalModeStr) {
+        mode = domain_bridge::DomainBridgeOptions::Mode::Normal;
+      } else {
+        std::cerr << "error: Invalid '--mode' option '" <<
+          mode_str << "'" << std::endl;
+        return std::make_pair(std::nullopt, 1);
+      }
+      continue;
+    }
+    if (yaml_config) {
+      std::cerr << "error: Can only specified one yaml configuration file '" <<
+        *it << "'" << std::endl;
+      return std::make_pair(std::nullopt, 1);
+    }
+    yaml_config = *it;
+  }
+  if (!yaml_config) {
+    std::cerr << "error: Must specify one yaml configuration file" << std::endl;
+    return std::make_pair(std::nullopt, 1);
+  }
+  domain_bridge::DomainBridgeConfig domain_bridge_config =
+    domain_bridge::parse_domain_bridge_yaml_config(*yaml_config);
+
+  // Override 'from_domain' and 'to_domain' in config
+  if (from_domain_id || to_domain_id) {
+    for (auto & topic_option_pair : domain_bridge_config.topics) {
+      if (from_domain_id) {
+        topic_option_pair.first.from_domain_id = *from_domain_id;
+      }
+      if (to_domain_id) {
+        topic_option_pair.first.to_domain_id = *to_domain_id;
+      }
+    }
+  }
+  if (mode) {
+    domain_bridge_config.options.mode(*mode);
+  }
+  return std::make_pair(domain_bridge_config, 0);
+}
+}  // namespace detail
+}  // namespace domain_bridge
+
+#endif  // PROCESS_CMD_LINE_ARGUMENTS_HPP_

--- a/src/process_cmd_line_arguments.hpp
+++ b/src/process_cmd_line_arguments.hpp
@@ -117,6 +117,11 @@ process_cmd_line_arguments(const std::vector<std::string> & args)
       continue;
     }
     if (arg == "--mode") {
+      if (mode) {
+        std::cerr << "error: --mode option passed more than once" << std::endl;
+        print_help();
+        return std::make_pair(std::nullopt, 1);
+      }
       ++it;
       const auto & mode_str = *it;
       if (mode_str == kCompressModeStr) {


### PR DESCRIPTION
I also moved the command line arguments parsing logic to a common function, that can be reused in both `domain_bridge` and `domain_bridge_rti_qos`.