### PR TITLE
Add reverse option to swap `from` and `to` domain IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ ros2 launch domain_bridge domain_bridge.launch.xml config:=examples/example_brid
 
 You can also override domain IDs with optional launch arguments `from_domain` and `to_domain`.
 
+To reverse the `from` and `to` domain IDs for a topic, set the `reversed` argument to `true`.
+
 Here is an example of including the domain bridge launch script into your own:
 
 ```xml

--- a/examples/example_bridge_config.yaml
+++ b/examples/example_bridge_config.yaml
@@ -11,17 +11,24 @@ topics:
     type: example_interfaces/msg/String
     # Override QoS reliablity setting to be best effort
     # This affects the domain bridge subscription and publisher
-    # This does NOT effect the other "chatter" bridge below, which is for a different domain
+    # This does NOT affect the other "chatter" bridge below, which is for a different domain
     qos:
       reliability: best_effort
   # Also bridge "/chatter" topic from doman ID 2 to domain ID 4
   chatter:
     type: example_interfaces/msg/String
     to_domain: 4
+  # Bridge reversed "/chatter" topic
+  chatter:
+    type: example_interfaces/msg/String
+    # Reverse 'from' and 'to' domains (bridge from domain ID 3 to domain ID 2)
+    reversed: True
   # Bridge bidirectional "/chatter" topic
   chatter:
     type: example_interfaces/msg/String
-    # Enable bridging from domain ID 2 to domain ID 3 AND from domain ID 3 to domain ID 2
+    from_domain: 7
+    to_domain: 8
+    # Bridge from domain ID 7 to domain ID 8 AND from domain ID 8 to domain ID 7
     bidirectional: True
 
   # Bridge "/chatter" topic from doman ID 2 to domain ID 3, but as "/chitter"

--- a/include/domain_bridge/topic_bridge_options.hpp
+++ b/include/domain_bridge/topic_bridge_options.hpp
@@ -104,6 +104,7 @@ private:
   std::string remap_name_;
 
   bool bidirectional_{false};
+
   bool reversed_{false};
 };  // class TopicBridgeOptions
 

--- a/include/domain_bridge/topic_bridge_options.hpp
+++ b/include/domain_bridge/topic_bridge_options.hpp
@@ -37,6 +37,7 @@ public:
    *    - callback_group = nullptr (node's default)
    *    - qos_options = default (see QosOptions for more information)
    *    - remap_name = "" (no remap)
+   *    - reversed = false
    */
   DOMAIN_BRIDGE_PUBLIC
   TopicBridgeOptions() = default;
@@ -74,12 +75,24 @@ public:
   TopicBridgeOptions &
   remap_name(const std::string & remap_name);
 
+  /// Get reversed option.
+  DOMAIN_BRIDGE_PUBLIC
+  const bool &
+  reversed() const;
+
+  /// Set reversed option.
+  DOMAIN_BRIDGE_PUBLIC
+  TopicBridgeOptions &
+  reversed(const bool & reversed);
+
 private:
   std::shared_ptr<rclcpp::CallbackGroup> callback_group_{nullptr};
 
   QosOptions qos_options_;
 
   std::string remap_name_;
+
+  bool reversed_{false};
 };  // class TopicBridgeOptions
 
 }  // namespace domain_bridge

--- a/include/domain_bridge/topic_bridge_options.hpp
+++ b/include/domain_bridge/topic_bridge_options.hpp
@@ -81,7 +81,7 @@ public:
   const bool &
   bidirectional() const;
 
-  /// Set bidirectional option.
+  /// Set bidirectional option. If true, this will bridge the topic in both directions.
   DOMAIN_BRIDGE_PUBLIC
   TopicBridgeOptions &
   bidirectional(const bool & bidirectional);
@@ -91,7 +91,7 @@ public:
   const bool &
   reversed() const;
 
-  /// Set reversed option.
+  /// Set reversed option. If true, this will swap the 'to' and 'from' domain IDs.
   DOMAIN_BRIDGE_PUBLIC
   TopicBridgeOptions &
   reversed(const bool & reversed);

--- a/src/domain_bridge/domain_bridge.cpp
+++ b/src/domain_bridge/domain_bridge.cpp
@@ -294,13 +294,6 @@ public:
         topic_options.remap_name(), options_.name(), "/");
     }
 
-    // Prevent using reversed flag and bidirectional flag at the same time
-    if (topic_options.reversed() && topic_options.bidirectional()) {
-      std::cerr << "Topic '" << topic << "' cannot use 'reversed' flag and" <<
-        " 'bidirectional' flag at the same time, ignoring" << std::endl;
-      return;
-    }
-
     const std::string & type = topic_bridge.type_name;
     std::size_t from_domain_id = topic_bridge.from_domain_id;
     std::size_t to_domain_id = topic_bridge.to_domain_id;

--- a/src/domain_bridge/domain_bridge.cpp
+++ b/src/domain_bridge/domain_bridge.cpp
@@ -294,9 +294,20 @@ public:
         topic_options.remap_name(), options_.name(), "/");
     }
 
+    // Prevent using reversed flag and bidirectional flag at the same time
+    if (topic_options.reversed() && topic_options.bidirectional()) {
+      std::cerr << "Topic '" << topic << "' cannot use 'reversed' flag and" <<
+        " 'bidirectional' flag at the same time, ignoring" << std::endl;
+      return;
+    }
+
     const std::string & type = topic_bridge.type_name;
-    const std::size_t & from_domain_id = topic_bridge.from_domain_id;
-    const std::size_t & to_domain_id = topic_bridge.to_domain_id;
+    std::size_t from_domain_id = topic_bridge.from_domain_id;
+    std::size_t to_domain_id = topic_bridge.to_domain_id;
+
+    if (topic_options.reversed()) {
+      std::swap(to_domain_id, from_domain_id);
+    }
 
     // Ensure 'to' domain and 'from' domain are not equal
     if (to_domain_id == from_domain_id) {

--- a/src/domain_bridge/parse_domain_bridge_yaml_config.cpp
+++ b/src/domain_bridge/parse_domain_bridge_yaml_config.cpp
@@ -229,6 +229,10 @@ DomainBridgeConfig parse_domain_bridge_yaml_config(std::filesystem::path file_pa
       }
       options.qos_options(parse_qos_options(topic_info, file_path));
 
+      if (topic_info["reversed"]) {
+        options.reversed(topic_info["reversed"].as<bool>());
+      }
+
       // Add topic bridge to config
       domain_bridge_config.topics.push_back({{topic, type, from_domain_id, to_domain_id}, options});
     }

--- a/src/domain_bridge/topic_bridge_options.cpp
+++ b/src/domain_bridge/topic_bridge_options.cpp
@@ -61,4 +61,17 @@ TopicBridgeOptions::remap_name(const std::string & remap_name)
   return *this;
 }
 
+const bool &
+TopicBridgeOptions::reversed() const
+{
+  return reversed_;
+}
+
+TopicBridgeOptions &
+TopicBridgeOptions::reversed(const bool & reversed)
+{
+  reversed_ = reversed;
+  return *this;
+}
+
 }  // namespace domain_bridge

--- a/test/domain_bridge/config/topic_options.yaml
+++ b/test/domain_bridge/config/topic_options.yaml
@@ -23,3 +23,4 @@ topics:
       deadline: auto
       lifespan: -5
     remap: ''
+    reversed: True

--- a/test/domain_bridge/test_domain_bridge.cpp
+++ b/test/domain_bridge/test_domain_bridge.cpp
@@ -161,6 +161,21 @@ TEST_F(TestDomainBridge, bridge_topic_invalid)
         "Topic '/foo' with type 'test_msgs/msg/BasicTypes' already bridged from "
         "domain 1 to domain 2, ignoring\n"));
   }
+  // Reversed and bidirectional
+  {
+    testing::internal::CaptureStderr();
+    domain_bridge::DomainBridge bridge;
+    domain_bridge::TopicBridgeOptions options;
+    options.reversed(true);
+    options.bidirectional(true);
+    bridge.bridge_topic({"foo", "test_msgs/msg/BasicTypes", 1u, 2u}, options);
+    std::string stderr_output = testing::internal::GetCapturedStderr();
+    EXPECT_THAT(
+      stderr_output,
+      ::testing::HasSubstr(
+        "Topic '/foo' cannot use 'reversed' flag and 'bidirectional' flag "
+        "at the same time, ignoring\n"));
+  }
 }
 
 TEST_F(TestDomainBridge, add_to_executor_valid)

--- a/test/domain_bridge/test_domain_bridge.cpp
+++ b/test/domain_bridge/test_domain_bridge.cpp
@@ -161,21 +161,6 @@ TEST_F(TestDomainBridge, bridge_topic_invalid)
         "Topic '/foo' with type 'test_msgs/msg/BasicTypes' already bridged from "
         "domain 1 to domain 2, ignoring\n"));
   }
-  // Reversed and bidirectional
-  {
-    testing::internal::CaptureStderr();
-    domain_bridge::DomainBridge bridge;
-    domain_bridge::TopicBridgeOptions options;
-    options.reversed(true);
-    options.bidirectional(true);
-    bridge.bridge_topic({"foo", "test_msgs/msg/BasicTypes", 1u, 2u}, options);
-    std::string stderr_output = testing::internal::GetCapturedStderr();
-    EXPECT_THAT(
-      stderr_output,
-      ::testing::HasSubstr(
-        "Topic '/foo' cannot use 'reversed' flag and 'bidirectional' flag "
-        "at the same time, ignoring\n"));
-  }
 }
 
 TEST_F(TestDomainBridge, add_to_executor_valid)

--- a/test/domain_bridge/test_domain_bridge_end_to_end.cpp
+++ b/test/domain_bridge/test_domain_bridge_end_to_end.cpp
@@ -276,3 +276,23 @@ TEST_F(TestDomainBridgeEndToEnd, create_bidirectional_bridge)
   ASSERT_TRUE(wait_for_publisher(node_1_, topic_name));
   ASSERT_TRUE(wait_for_publisher(node_2_, topic_name));
 }
+
+TEST_F(TestDomainBridgeEndToEnd, create_reversed_bridge)
+{
+  const std::string topic_name("test_reversed");
+
+  // Create a publisher on domain 1
+  auto pub = node_1_->create_publisher<test_msgs::msg::BasicTypes>(topic_name, 1);
+
+  // Bridge the publisher topic in the reversed direction
+  domain_bridge::DomainBridge bridge;
+  domain_bridge::TopicBridgeOptions topic_bridge_options;
+  topic_bridge_options.reversed(true);
+  bridge.bridge_topic(
+    {topic_name, "test_msgs/msg/BasicTypes", kDomain2, kDomain1},
+    topic_bridge_options
+  );
+
+  // 'to' domain is 1, but since the bridge is reversed, publisher should only appear on domain 2
+  ASSERT_TRUE(wait_for_publisher(node_2_, topic_name));
+}

--- a/test/domain_bridge/test_parse_domain_bridge_yaml_config.cpp
+++ b/test/domain_bridge/test_parse_domain_bridge_yaml_config.cpp
@@ -129,6 +129,7 @@ TEST_F(TestParseDomainBridgeYamlConfig, topic_options)
       .deadline_auto()
       .lifespan(-5))
     .remap_name("")
+    .reversed(true)
   };
   const std::string yaml_path =
     (test_yaml_dir_ / std::filesystem::path{"topic_options.yaml"}).string();
@@ -148,6 +149,7 @@ TEST_F(TestParseDomainBridgeYamlConfig, topic_options)
       config.topics[i].second.qos_options().depth(), expected[i].qos_options().depth());
     EXPECT_EQ(config.topics[i].second.remap_name(), expected[i].remap_name());
     EXPECT_EQ(config.topics[i].second.bidirectional(), expected[i].bidirectional());
+    EXPECT_EQ(config.topics[i].second.reversed(), expected[i].reversed());
   }
 }
 


### PR DESCRIPTION
As a follow-up to #39, this PR adds an option to reverse the _from_ and _to_ domain IDs when bridging a topic.