### PR TITLE
Fix bug when waiting for service to be available

### DIFF
--- a/src/domain_bridge/wait_for_graph_events.hpp
+++ b/src/domain_bridge/wait_for_graph_events.hpp
@@ -331,7 +331,11 @@ private:
             t.cv.wait(
               lock,
               [&t]
-              {return (t.topic_callback_vec.size() > 0u) || t.shutting_down;});
+              {
+                return (t.topic_callback_vec.size() > 0u) ||
+                (t.service_callback_vec.size() > 0u) ||
+                t.shutting_down;
+              });
           }
         }
       };


### PR DESCRIPTION
Also check the vector of service callbacks when deciding if we should continue
executing the wait loop in WaitforGraphEvents threads.

Fixes https://github.com/ros2/domain_bridge/issues/41