### PR TITLE
Run communication-related tests with all available RMWs

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <test_depend>launch</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>rmw_implementation_cmake</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,11 @@
   <test_depend>rmw_implementation_cmake</test_depend>
   <test_depend>test_msgs</test_depend>
 
+  <!-- Ensure the following Tier 1 RMW implementations are available for testing -->
+  <test_depend>rmw_connextdds</test_depend>
+  <test_depend>rmw_cyclonedds_cpp</test_depend>
+  <test_depend>rmw_fastrtps_cpp</test_depend>
+
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(ament_cmake_gmock REQUIRED)
 find_package(ament_cmake_gtest REQUIRED)
 find_package(launch_testing_ament_cmake REQUIRED)
+find_package(rmw_implementation_cmake REQUIRED)
 find_package(test_msgs REQUIRED)
 
 ament_add_gmock(test_domain_bridge
@@ -21,38 +22,46 @@ if(TARGET test_parse_domain_bridge_yaml_config)
   target_link_libraries(test_parse_domain_bridge_yaml_config ${PROJECT_NAME}_lib)
 endif()
 
-ament_add_gmock(test_qos_matching
-  domain_bridge/test_qos_matching.cpp
-)
-if(TARGET test_qos_matching)
-  ament_target_dependencies(test_qos_matching
-    "rclcpp"
-    "test_msgs"
+# The following tests are run for each available RMW implementation
+function(add_communication_tests)
+  set(rmw_implementation_env RMW_IMPLEMENTATION=${rmw_implementation})
+  ament_add_gmock(test_qos_matching${target_suffix}
+    domain_bridge/test_qos_matching.cpp
+    ENV ${rmw_implementation_env}
   )
-  target_link_libraries(test_qos_matching ${PROJECT_NAME}_lib)
-endif()
+  if(TARGET test_qos_matching${target_suffix})
+    ament_target_dependencies(test_qos_matching${target_suffix}
+      "rclcpp"
+      "test_msgs"
+    )
+    target_link_libraries(test_qos_matching${target_suffix} ${PROJECT_NAME}_lib)
+  endif()
 
-ament_add_gmock(test_domain_bridge_end_to_end
-  domain_bridge/test_domain_bridge_end_to_end.cpp
-)
-if(TARGET test_domain_bridge_end_to_end)
-  ament_target_dependencies(test_domain_bridge_end_to_end
-    "rclcpp"
-    "test_msgs"
+  ament_add_gmock(test_domain_bridge_end_to_end${target_suffix}
+    domain_bridge/test_domain_bridge_end_to_end.cpp
+    ENV ${rmw_implementation_env}
   )
-  target_link_libraries(test_domain_bridge_end_to_end ${PROJECT_NAME}_lib)
-endif()
+  if(TARGET test_domain_bridge_end_to_end${target_suffix})
+    ament_target_dependencies(test_domain_bridge_end_to_end${target_suffix}
+      "rclcpp"
+      "test_msgs"
+    )
+    target_link_libraries(test_domain_bridge_end_to_end${target_suffix} ${PROJECT_NAME}_lib)
+  endif()
 
-ament_add_gmock(test_domain_bridge_services
-  domain_bridge/test_domain_bridge_services.cpp
-)
-if(TARGET test_domain_bridge_services)
-  ament_target_dependencies(test_domain_bridge_services
-    "rclcpp"
-    "test_msgs"
+  ament_add_gmock(test_domain_bridge_services${target_suffix}
+    domain_bridge/test_domain_bridge_services.cpp
+    ENV ${rmw_implementation_env}
   )
-  target_link_libraries(test_domain_bridge_services ${PROJECT_NAME}_lib)
-endif()
+  if(TARGET test_domain_bridge_services${target_suffix})
+    ament_target_dependencies(test_domain_bridge_services${target_suffix}
+      "rclcpp"
+      "test_msgs"
+    )
+    target_link_libraries(test_domain_bridge_services${target_suffix} ${PROJECT_NAME}_lib)
+  endif()
+endfunction()
+call_for_each_rmw_implementation(add_communication_tests)
 
 # Test executable
 add_launch_test(


### PR DESCRIPTION
Follow-up to https://github.com/ros2/domain_bridge/issues/41.
Hopefully this will prevent regressions for RMWs that are not the ROS 2 default.