### PR TITLE
Use unambiguous call to shared_from_this()

### DIFF
--- a/include/domain_bridge/service_bridge_impl.inc
+++ b/include/domain_bridge/service_bridge_impl.inc
@@ -99,7 +99,10 @@ public:
     // send_response(*request_header, *response);
     // ***
     // The hack: forget about sending a response immediately.
-    callback_(this->shared_from_this(), request_header, typed_request);
+    callback_(
+      std::enable_shared_from_this<HackedService<ServiceT>>::shared_from_this(),
+      request_header,
+      typed_request);
   }
 private:
   // any_callback_ is private in service, we will use our own callback implementation.


### PR DESCRIPTION
This fixes a compilation error when building against the latest version of rclcpp:

```
 error: request for member 'shared_from_this' is ambiguous
  116 |     callback_(this->shared_from_this(), request_header, typed_request);
      |               ~~~~~~^~~~~~~~~~~~~~~~
```