### PR TITLE
Use defered service support in rclcpp

### DIFF
--- a/include/domain_bridge/service_bridge_impl.inc
+++ b/include/domain_bridge/service_bridge_impl.inc
@@ -54,79 +54,6 @@ get_node_for_domain(DomainBridgeImpl & impl, std::size_t domain_id);
 
 const std::string &
 get_node_name(const DomainBridgeImpl & impl);
-
-/// \internal
-/// An "awesome" hack on top of `rclcpp::Service`.
-/**
- * This is needed because you cannot currently get a request and defer to send
- * a response.
- * To put it in another way, you cannot spin during a service callback.
- * 
- * In this case, we need to call another service in our service callbacks, so we need
- * this beautiful hack :).
- * 
- * TODO(ivanpauno): There should be first class support for this in rclcpp.
- */
-template<typename ServiceT>
-class HackedService
-: public rclcpp::Service<ServiceT>,
-  public std::enable_shared_from_this<HackedService<ServiceT>>
-{
-public:
-  using CallbackT = std::function<void(
-    std::shared_ptr<HackedService<ServiceT>>,
-    const std::shared_ptr<rmw_request_id_t> &,
-    const std::shared_ptr<typename ServiceT::Request> &)>;
-
-  HackedService(
-    std::shared_ptr<rcl_node_t> node_handle,
-    const std::string & service_name,
-    CallbackT my_callback,
-    rcl_service_options_t & service_options)
-  : rclcpp::Service<ServiceT>(node_handle, service_name, rclcpp::AnyServiceCallback<ServiceT>{}, service_options),
-    callback_(std::move(my_callback)) {}
-
-  void
-  handle_request(
-    std::shared_ptr<rmw_request_id_t> request_header,
-    std::shared_ptr<void> request) override
-  {
-    auto typed_request = std::static_pointer_cast<typename ServiceT::Request>(request);
-    // Original implementation:
-    // ***
-    // auto response = std::make_shared<typename ServiceT::Response>();
-    // any_callback_.dispatch(request_header, typed_request, response);
-    // send_response(*request_header, *response);
-    // ***
-    // The hack: forget about sending a response immediately.
-    callback_(
-      std::enable_shared_from_this<HackedService<ServiceT>>::shared_from_this(),
-      request_header,
-      typed_request);
-  }
-private:
-  // any_callback_ is private in service, we will use our own callback implementation.
-  CallbackT callback_;
-};
-
-/// Create a service with a given type.
-/// \internal
-template<typename ServiceT>
-typename std::shared_ptr<HackedService<ServiceT>>
-create_hacked_service(
-  std::shared_ptr<rclcpp::Node> node,
-  const std::string & service_name,
-  typename HackedService<ServiceT>::CallbackT callback,
-  rclcpp::CallbackGroup::SharedPtr group)
-{
-  rcl_service_options_t service_options = rcl_service_get_default_options();
-  auto serv = std::make_shared<HackedService<ServiceT>>(
-    node->get_node_base_interface()->get_shared_rcl_node_handle(),
-    service_name, std::move(callback), service_options);
-  auto serv_base_ptr = std::static_pointer_cast<rclcpp::ServiceBase>(serv);
-  node->get_node_services_interface()->add_service(serv_base_ptr, group);
-  return serv;
-}
 }  // namespace detail
 
 /// Bridge a service from one domain to another.
@@ -181,9 +108,9 @@ DomainBridge::bridge_service(
 
   auto handle_request =
     [client](
-      std::shared_ptr<detail::HackedService<ServiceT>> me,
-      const std::shared_ptr<rmw_request_id_t> & request_header,
-      const std::shared_ptr<typename ServiceT::Request> & request) -> void
+      std::shared_ptr<rclcpp::Service<ServiceT>> me,
+      std::shared_ptr<rmw_request_id_t> request_header,
+      std::shared_ptr<typename ServiceT::Request> request) -> void
     {
       // TODO(ivanpauno): What do we do if the original server is down?
       // This is a general problem in ROS 2, we don't have a clean way of communicating a service error ....
@@ -207,10 +134,10 @@ DomainBridge::bridge_service(
     handle_request = std::move(handle_request),
     options = std::move(options)]()
   {
-    return detail::create_hacked_service<ServiceT>(
-      to_domain_node,
+    return to_domain_node->create_service<ServiceT>(
       service_remapped,
       handle_request,
+      rmw_qos_profile_services_default,
       options.callback_group());
   };
 

--- a/include/domain_bridge/service_bridge_impl.inc
+++ b/include/domain_bridge/service_bridge_impl.inc
@@ -99,7 +99,10 @@ public:
     // send_response(*request_header, *response);
     // ***
     // The hack: forget about sending a response immediately.
-    callback_(this->shared_from_this(), request_header, typed_request);
+    callback_(
+      std::enable_shared_from_this<HackedService<ServiceT>>::shared_from_this(),
+      request_header,
+      typed_request);
   }
 private:
   // any_callback_ is private in service, we will use our own callback implementation.


### PR DESCRIPTION
Replaces https://github.com/ros2/domain_bridge/pull/48.

Multiple inheritance with `std::enable_shared_from_this` is problematic, see:

- https://stackoverflow.com/questions/16082785/use-of-enable-shared-from-this-with-multiple-inheritance
- https://stackoverflow.com/questions/15549722/double-inheritance-of-enable-shared-from-this
- https://stackoverflow.com/questions/12790859/bad-weak-pointer-when-base-and-derived-class-both-inherit-from-boostenable-sha
- https://stackoverflow.com/questions/14939190/boost-shared-from-this-and-multiple-inheritance

The solutions proposed in those threads cannot directly applied here.

To avoid the issue, I'm using the support for defering responses in services added in rclcpp, avoiding the need of using `std::enable_shared_from_this` all together.
We will need a new branch for rolling though, but I couldn't find a backwards compatible solution.