### PR TITLE
Add missing dependency in test_component_lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ if(BUILD_TESTING)
   )
   ament_target_dependencies(${PROJECT_NAME}_test_component_lib
     rclcpp
+    rclcpp_components
     test_msgs
   )
   rclcpp_components_register_node(${PROJECT_NAME}_test_component_lib


### PR DESCRIPTION
Locally, I get an error without this patch:

```
[Processing: domain_bridge]
--- stderr: domain_bridge
/home/ivanpauno/ros2_ws/other_ws/domain_bridge_ws/src/domain_bridge/test/domain_bridge/test_component.cpp:16:10: fatal error: rclcpp_components/register_node_macro.hpp: No such file or directory
   16 | #include "rclcpp_components/register_node_macro.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/domain_bridge_test_component_lib.dir/build.make:63: CMakeFiles/domain_bridge_test_component_lib.dir/test/domain_bridge/test_component.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:705: CMakeFiles/domain_bridge_test_component_lib.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:141: all] Error 2
```

CI was passing though, IDK why.