### PR TITLE
Do not associate test library with export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,12 @@ if(BUILD_TESTING)
   rclcpp_components_register_node(${PROJECT_NAME}_test_component_lib
     PLUGIN "domain_bridge::TestComponent"
     EXECUTABLE test_component)
+
+  install(TARGETS ${PROJECT_NAME}_test_component_lib
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION lib/${PROJECT_NAME}
+  )
 endif()
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,13 +156,6 @@ if(BUILD_TESTING)
   rclcpp_components_register_node(${PROJECT_NAME}_test_component_lib
     PLUGIN "domain_bridge::TestComponent"
     EXECUTABLE test_component)
-
-  install(TARGETS ${PROJECT_NAME}_test_component_lib
-    EXPORT export_${PROJECT_NAME}
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION lib/${PROJECT_NAME}
-  )
 endif()
 
 ament_package()


### PR DESCRIPTION
Otherwise, downstream targets will try to link against it.
This can cause issues linking because the test component library is not exporting dependencies (e.g. test_msgs).