### PR TITLE
Add workflow action to setup Python 3.8

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.6'
     - uses: ros-tooling/setup-ros@v0.2
       with:
         install-connext: true


### PR DESCRIPTION
Attempt to force CI to use Python 3.

The workflow is failing, [for example](https://github.com/ros2/domain_bridge/runs/4122843883):

```
...
 -- Found PythonInterp: /usr/bin/python (found version "2.7.18") 
  CMake Error at /opt/ros/rolling/share/rosidl_adapter/cmake/rosidl_adapt_interfaces.cmake:60 (message):
    execute_process(/usr/bin/python -m rosidl_adapter --package-name
    domain_bridge --arguments-file
    /home/runner/work/domain_bridge/domain_bridge/ros_ws/build/domain_bridge/rosidl_adapter__arguments__domain_bridge.json
    --output-dir
    /home/runner/work/domain_bridge/domain_bridge/ros_ws/build/domain_bridge/rosidl_adapter/domain_bridge
    --output-file
    /home/runner/work/domain_bridge/domain_bridge/ros_ws/build/domain_bridge/rosidl_adapter/domain_bridge.idls)
    returned error code 1:
  
    Traceback (most recent call last):
  
      File "/usr/lib/python2.7/runpy.py", line 163, in _run_module_as_main
        mod_name, _Error)
      File "/usr/lib/python2.7/runpy.py", line 111, in _get_module_details
        __import__(mod_name)  # Do not catch exceptions initializing package
      File "/opt/ros/rolling/lib/python3.8/site-packages/rosidl_adapter/__init__.py", line 32
        assert False, f"Unsupported interface type '{interface_file.suffix}'"
                                                                            ^
  
    SyntaxError: invalid syntax

```