### PR TITLE
Auto remove bridge when endpoint removed

### DIFF
--- a/include/domain_bridge/process_cmd_line_arguments.hpp
+++ b/include/domain_bridge/process_cmd_line_arguments.hpp
@@ -63,8 +63,7 @@ print_help()
     " passed, when either the subscrption or publisher is removed also will the bridge."
     " If only --wait-for-subscription was passed, the bridge will only be removed if the"
     " subscription is."
-    " The bridge will be created again when the original \"wait for\" condition is satisfied"
-    " again." <<
+    " The bridge will be recreated when the original \"wait for\" condition is satisfied." <<
     std::endl <<
     "    --help, -h               Print this help message." << std::endl;
 }

--- a/include/domain_bridge/process_cmd_line_arguments.hpp
+++ b/include/domain_bridge/process_cmd_line_arguments.hpp
@@ -58,8 +58,8 @@ print_help()
     "    --wait-for-publisher true|false  Will wait for an available subscription before"
     " bridging a topic. This overrides any value set in the YAML file. Defaults to true." <<
     std::endl <<
-    "    --auto-remove true|false  If true, the bridge will be removed if endpoint was waited"
-    " for is removed. i.e. if both --wait-for-subscription and --wait-for-publisher where "
+    "    --auto-remove true|false  If true, the bridge will be removed if the endpoint that was waited"
+    " on is removed. I.e. if both --wait-for-subscription and --wait-for-publisher were "
     " passed, when either the subscrption or publisher is removed also will the bridge."
     " If only --wait-for-subscription was passed, the bridge will only be removed if the"
     " subscription is."

--- a/include/domain_bridge/process_cmd_line_arguments.hpp
+++ b/include/domain_bridge/process_cmd_line_arguments.hpp
@@ -60,7 +60,7 @@ print_help()
     std::endl <<
     "    --auto-remove true|false  If true, the bridge will be removed if the endpoint that was waited"
     " on is removed. I.e. if both --wait-for-subscription and --wait-for-publisher were "
-    " passed, when either the subscrption or publisher is removed also will the bridge."
+    " passed, then when either the subscription or publisher is removed, the bridge will also be removed."
     " If only --wait-for-subscription was passed, the bridge will only be removed if the"
     " subscription is."
     " The bridge will be recreated when the original \"wait for\" condition is satisfied." <<

--- a/include/domain_bridge/process_cmd_line_arguments.hpp
+++ b/include/domain_bridge/process_cmd_line_arguments.hpp
@@ -268,7 +268,7 @@ process_cmd_line_arguments(const std::vector<std::string> & args)
   domain_bridge::DomainBridgeConfig domain_bridge_config =
     domain_bridge::parse_domain_bridge_yaml_config(*yaml_config);
 
-  // Override 'from_domain','to_domain' and 'wait_for_subscription' in config
+  // Override domain bridge configuration options
   if (
     from_domain_id || to_domain_id || wait_for_subscription || wait_for_publisher ||
     auto_remove)

--- a/include/domain_bridge/process_cmd_line_arguments.hpp
+++ b/include/domain_bridge/process_cmd_line_arguments.hpp
@@ -58,9 +58,10 @@ print_help()
     "    --wait-for-publisher true|false  Will wait for an available subscription before"
     " bridging a topic. This overrides any value set in the YAML file. Defaults to true." <<
     std::endl <<
-    "    --auto-remove true|false  If true, the bridge will be removed if the endpoint that was waited"
-    " on is removed. I.e. if both --wait-for-subscription and --wait-for-publisher were "
-    " passed, then when either the subscription or publisher is removed, the bridge will also be removed."
+    "    --auto-remove true|false  If true, the bridge will be removed if the endpoint that was"
+    " waited on is removed. I.e. if both --wait-for-subscription and --wait-for-publisher were"
+    " passed, then when either the subscription or publisher is removed, the bridge will also be"
+    " removed."
     " If only --wait-for-subscription was passed, the bridge will only be removed if the"
     " subscription is."
     " The bridge will be recreated when the original \"wait for\" condition is satisfied." <<

--- a/include/domain_bridge/topic_bridge_options.hpp
+++ b/include/domain_bridge/topic_bridge_options.hpp
@@ -146,6 +146,7 @@ public:
   {
     OnNoPublisher,
     OnNoSubscription,
+    OnNoPublisherOrSubscription,
     Disabled,
   };
 

--- a/include/domain_bridge/topic_bridge_options.hpp
+++ b/include/domain_bridge/topic_bridge_options.hpp
@@ -41,7 +41,7 @@ public:
    *    - reversed = false
    *    - wait_for_subscription = false
    *    - wait_for_publisher = true
-   *    - auto_remove = Autoremove::Disabled
+   *    - auto_remove = AutoRemove::Disabled
    *    - delay = 0 (no extra delay to wait for publishers before creating bridge)
    */
   DOMAIN_BRIDGE_PUBLIC
@@ -152,15 +152,15 @@ public:
 
   /// Set auto_remove to value.
   /**
-   * If set to Autoremove::OnNoPublisher the domain bridge will stop bridging when no publisher is
+   * If set to AutoRemove::OnNoPublisher the domain bridge will stop bridging when no publisher is
    * available in the "from domain".
    * The bridge will automatically be created again when a new publisher is discovered.
    *
-   * If set to Autoremove::OnNoSubscription the domain bridge will stop bridging when no
+   * If set to AutoRemove::OnNoSubscription the domain bridge will stop bridging when no
    * subscription is available in the "to domain".
    * The bridge will automatically be created again when a new subscription is discovered.
    *
-   * When set to Autoremove::Disabled, the bridge will keep running forever once created.
+   * When set to AutoRemove::Disabled, the bridge will keep running forever once created.
    */
   DOMAIN_BRIDGE_PUBLIC
   TopicBridgeOptions &

--- a/include/domain_bridge/topic_bridge_options.hpp
+++ b/include/domain_bridge/topic_bridge_options.hpp
@@ -41,6 +41,7 @@ public:
    *    - reversed = false
    *    - wait_for_subscription = false
    *    - wait_for_publisher = true
+   *    - auto_remove = Autoremove::Disabled
    *    - delay = 0 (no extra delay to wait for publishers before creating bridge)
    */
   DOMAIN_BRIDGE_PUBLIC
@@ -141,6 +142,34 @@ public:
   bool
   wait_for_publisher() const;
 
+  enum class AutoRemove
+  {
+    OnNoPublisher,
+    OnNoSubscription,
+    Disabled,
+  };
+
+  /// Set auto_remove to value.
+  /**
+   * If set to Autoremove::OnNoPublisher the domain bridge will stop bridging when no publisher is
+   * available in the "from domain".
+   * The bridge will automatically be created again when a new publisher is discovered.
+   *
+   * If set to Autoremove::OnNoSubscription the domain bridge will stop bridging when no
+   * subscription is available in the "to domain".
+   * The bridge will automatically be created again when a new subscription is discovered.
+   *
+   * When set to Autoremove::Disabled, the bridge will keep running for ever once created.
+   */
+  DOMAIN_BRIDGE_PUBLIC
+  TopicBridgeOptions &
+  auto_remove(AutoRemove value);
+
+  /// Get remove_if_no_publisher option.
+  DOMAIN_BRIDGE_PUBLIC
+  AutoRemove
+  auto_remove() const;
+
 private:
   std::shared_ptr<rclcpp::CallbackGroup> callback_group_{nullptr};
 
@@ -155,6 +184,8 @@ private:
   bool wait_for_subscription_{false};
 
   bool wait_for_publisher_{true};
+
+  AutoRemove auto_remove_{AutoRemove::Disabled};
 
   std::chrono::milliseconds delay_{0};
 };  // class TopicBridgeOptions

--- a/include/domain_bridge/topic_bridge_options.hpp
+++ b/include/domain_bridge/topic_bridge_options.hpp
@@ -160,7 +160,7 @@ public:
    * subscription is available in the "to domain".
    * The bridge will automatically be created again when a new subscription is discovered.
    *
-   * When set to Autoremove::Disabled, the bridge will keep running for ever once created.
+   * When set to Autoremove::Disabled, the bridge will keep running forever once created.
    */
   DOMAIN_BRIDGE_PUBLIC
   TopicBridgeOptions &

--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,7 @@
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
+  <test_depend>rosgraph_msgs</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <!-- Ensure the following Tier 1 RMW implementations are available for testing -->

--- a/src/domain_bridge/domain_bridge.cpp
+++ b/src/domain_bridge/domain_bridge.cpp
@@ -460,15 +460,21 @@ public:
         unreachable();
     }
     if (
-      domain_bridge::TopicBridgeOptions::AutoRemove::OnNoPublisher == topic_options.auto_remove())
+      domain_bridge::TopicBridgeOptions::AutoRemove::OnNoPublisher ==
+      topic_options.auto_remove() ||
+      domain_bridge::TopicBridgeOptions::AutoRemove::OnNoPublisherOrSubscription ==
+      topic_options.auto_remove())
     {
       this->wait_for_graph_events_.register_on_no_publisher_callback(
         topic, from_domain_node, [this, topic_bridge]() {
           this->bridged_topics_[topic_bridge] = {nullptr, nullptr};
         }
       );
-    } else if (
+    }
+    if (
       domain_bridge::TopicBridgeOptions::AutoRemove::OnNoSubscription ==
+      topic_options.auto_remove() ||
+      domain_bridge::TopicBridgeOptions::AutoRemove::OnNoPublisherOrSubscription ==
       topic_options.auto_remove())
     {
       this->wait_for_graph_events_.register_on_no_subscription_callback(

--- a/src/domain_bridge/topic_bridge_options.cpp
+++ b/src/domain_bridge/topic_bridge_options.cpp
@@ -126,4 +126,17 @@ TopicBridgeOptions::wait_for_publisher() const
   return wait_for_publisher_;
 }
 
+TopicBridgeOptions &
+TopicBridgeOptions::auto_remove(TopicBridgeOptions::AutoRemove value)
+{
+  auto_remove_ = value;
+  return *this;
+}
+
+TopicBridgeOptions::AutoRemove
+TopicBridgeOptions::auto_remove() const
+{
+  return auto_remove_;
+}
+
 }  // namespace domain_bridge

--- a/src/domain_bridge/wait_for_graph_events.hpp
+++ b/src/domain_bridge/wait_for_graph_events.hpp
@@ -362,10 +362,8 @@ private:
                   if (!opt_qos) {
                     auto callback = std::get<std::function<void()>>(callback_variant);
                     callback();
-                    it = t.topics_callback_vec.erase(it);
-                  } else {
-                    ++it;
                   }
+                  ++it;
                 } else {
                   // waiting for discovered entity
                   if (opt_qos) {
@@ -373,10 +371,8 @@ private:
                       callback_variant);
                     const QosMatchInfo & qos = opt_qos.value();
                     callback(qos);
-                    it = t.topics_callback_vec.erase(it);
-                  } else {
-                    ++it;
                   }
+                  ++it;
                 }
               }
             }

--- a/src/domain_bridge/wait_for_graph_events.hpp
+++ b/src/domain_bridge/wait_for_graph_events.hpp
@@ -413,13 +413,11 @@ private:
       if (opt_qos) {
         const QosMatchInfo & qos = opt_qos.value();
         callback(qos);
-        return;
       }
     } else if constexpr (std::is_same_v<T, std::function<void()>>) {  // NOLINT, cpplint false positive
       // notify when no entity is available
       if (!opt_qos) {
         callback();
-        return;
       }
     } else {
       static_assert(

--- a/src/domain_bridge/wait_for_graph_events.hpp
+++ b/src/domain_bridge/wait_for_graph_events.hpp
@@ -15,8 +15,9 @@
 #ifndef DOMAIN_BRIDGE__WAIT_FOR_GRAPH_EVENTS_HPP_
 #define DOMAIN_BRIDGE__WAIT_FOR_GRAPH_EVENTS_HPP_
 
-// Silly cpplint thinks this is a C system header
+// Silly cpplint thinks these are C system headers
 #include <optional>
+#include <variant>
 
 #include <atomic>
 #include <chrono>
@@ -27,7 +28,6 @@
 #include <thread>
 #include <unordered_map>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include "rclcpp/client.hpp"

--- a/src/domain_bridge/wait_for_graph_events.hpp
+++ b/src/domain_bridge/wait_for_graph_events.hpp
@@ -394,7 +394,8 @@ private:
   }
 
   // helper
-  template<class> static inline constexpr bool always_false_v = false;
+  template<class>
+  static inline constexpr bool always_false_v = false;
 
   template<typename CallbackT>
   void register_on_pubsub_callback(
@@ -414,7 +415,7 @@ private:
         callback(qos);
         return;
       }
-    } else if constexpr (std::is_same_v<T, std::function<void()>>) {
+    } else if constexpr (std::is_same_v<T, std::function<void()>>) {  // NOLINT, cpplint false positive
       // notify when no entity is available
       if (!opt_qos) {
         callback();
@@ -423,7 +424,8 @@ private:
     } else {
       static_assert(
         always_false_v<T>,
-        "callback should either be std::function<void(const QosMatchInfo)> or std::function<void()>");
+        "callback should either be std::function<void(const QosMatchInfo)>"
+        " or std::function<void()>");
     }
 
     std::lock_guard<std::mutex> lock(mutex_);

--- a/src/domain_bridge/wait_for_graph_events.hpp
+++ b/src/domain_bridge/wait_for_graph_events.hpp
@@ -27,6 +27,7 @@
 #include <thread>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "rclcpp/client.hpp"


### PR DESCRIPTION
The callbacks added to the `WaitForGraphEvents` object are now kept forever instead of being removed after the first time they are called.
There might be another way to get this working (register callback waiting for publishing/subscription, remove it and register the one waiting for publisher/subscription/removed, ...), though I find that more complex to implement in the current code.