### PR TITLE
Fixes for Ubuntu Jammy

### DIFF
--- a/test/domain_bridge/test_domain_bridge.cpp
+++ b/test/domain_bridge/test_domain_bridge.cpp
@@ -47,7 +47,7 @@ TEST_F(TestDomainBridge, construction_destruction)
   }
   // With options
   {
-    domain_bridge::DomainBridge bridge(domain_bridge::DomainBridgeOptions());
+    domain_bridge::DomainBridge bridge{domain_bridge::DomainBridgeOptions()};
   }
 }
 

--- a/test/domain_bridge/wait_for_publisher.hpp
+++ b/test/domain_bridge/wait_for_publisher.hpp
@@ -48,7 +48,7 @@ inline bool wait_for_publisher(
     time_slept = std::chrono::duration_cast<std::chrono::microseconds>(
       std::chrono::steady_clock::now() - start);
   } while (!predicate() &&
-    time_slept < std::chrono::duration_cast<std::chrono::microseconds>(timeout));
+  time_slept < std::chrono::duration_cast<std::chrono::microseconds>(timeout));
 
   return predicate();
 }


### PR DESCRIPTION
* Fix -Wvesing-parse compiler warning (1d5dbc8bdd348f8d23cf35aca8fb99f319a52a11)
Use braces to initialize variable instead of parentheses.
* Uncrustify (578137bbe7958a2efc08c95fe7624426fa9fc56b)