### PR TITLE
[README] Fix API docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,4 @@ Here is an example of including the domain bridge launch script into your own:
 
 ### C++ library
 
-There is a C++ API that can be integrated into your own process, you can find the [API docs here](TODO).
+There is a C++ API that can be integrated into your own process, you can find the [API docs here](https://docs.ros.org/en/ros2_packages/rolling/api/domain_bridge/index.html).


### PR DESCRIPTION
Since rosdoc2 generated API docs are now hosted online, the link in the
README can point to the appropriate resource.

Closes #65.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>