### PR TITLE
[humble] Update CI to target Humble

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -11,8 +11,8 @@ jobs:
       with:
         install-connext: true
         use-ros2-testing: true
-        required-ros-distributions: rolling
+        required-ros-distributions: humble
     - uses: ros-tooling/action-ros-ci@v0.2
       with:
         package-name: domain_bridge
-        target-ros2-distro: rolling
+        target-ros2-distro: humble


### PR DESCRIPTION
Related PRs:
- https://github.com/ros/rosdistro/pull/34699
- https://github.com/ros2-gbp/domain_bridge-release/pull/1