### PR TITLE
Allow to bridge between ROS_LOCALHOST=0 and ROS_LOCALHOST=1

### DIFF
--- a/include/domain_bridge/domain_bridge.hpp
+++ b/include/domain_bridge/domain_bridge.hpp
@@ -114,6 +114,8 @@ public:
    * \param type: Name of the topic type (e.g. "example_interfaces/msg/String")
    * \param from_domain_id: Domain ID the bridge will use to subscribe to the topic.
    * \param to_domain_id: Domain ID the bridge will use to publish to the topic.
+   * \param from_local_host_only: Indicates the localhost mode that apply to the subscriber of the topic.
+   * \param to_local_host_only: Indicates the localhost mode that apply to the publisher of the topic.
    * \param options: Options for bridging the topic.
    */
   DOMAIN_BRIDGE_PUBLIC
@@ -122,6 +124,8 @@ public:
     const std::string & type,
     size_t from_domain_id,
     size_t to_domain_id,
+    DomainBridgeOptions::LocalHostOnly from_local_host_only,
+    DomainBridgeOptions::LocalHostOnly to_local_host_only,
     const TopicBridgeOptions & options = TopicBridgeOptions());
 
   /// Bridge a topic from one domain to another.
@@ -146,6 +150,8 @@ public:
     const std::string & service,
     size_t from_domain_id,
     size_t to_domain_id,
+    DomainBridgeOptions::LocalHostOnly from_local_host_only,
+    DomainBridgeOptions::LocalHostOnly to_local_host_only,
     const ServiceBridgeOptions & options = ServiceBridgeOptions());
 
   /// Get bridged topics.

--- a/include/domain_bridge/domain_bridge_options.hpp
+++ b/include/domain_bridge/domain_bridge_options.hpp
@@ -30,6 +30,10 @@ class DomainBridgeImpl;
 class DomainBridgeOptions
 {
 public:
+  enum class LocalHostOnly
+  {
+    Default, Enabled, Disabled
+  };
   enum class Mode
   {
     Normal,

--- a/include/domain_bridge/service_bridge_impl.inc
+++ b/include/domain_bridge/service_bridge_impl.inc
@@ -50,7 +50,7 @@ add_service_bridge(
   std::shared_ptr<rclcpp::ClientBase> client);
 
 rclcpp::Node::SharedPtr
-get_node_for_domain(DomainBridgeImpl & impl, std::size_t domain_id);
+get_node_for_domain(DomainBridgeImpl & impl, std::size_t domain_id, domain_bridge::DomainBridgeOptions::LocalHostOnly local_host_only);
 
 const std::string &
 get_node_name(const DomainBridgeImpl & impl);
@@ -67,6 +67,8 @@ DomainBridge::bridge_service(
   const std::string & service_name,
   size_t from_domain_id,
   size_t to_domain_id,
+  DomainBridgeOptions::LocalHostOnly from_local_host_only,
+  DomainBridgeOptions::LocalHostOnly to_local_host_only,
   const ServiceBridgeOptions & options)
 {
   const auto & node_name = detail::get_node_name(*impl_);
@@ -97,8 +99,8 @@ DomainBridge::bridge_service(
     return;
   }
 
-  rclcpp::Node::SharedPtr from_domain_node = detail::get_node_for_domain(*impl_, from_domain_id);
-  rclcpp::Node::SharedPtr to_domain_node = detail::get_node_for_domain(*impl_, to_domain_id);
+  rclcpp::Node::SharedPtr from_domain_node = detail::get_node_for_domain(*impl_, from_domain_id, from_local_host_only);
+  rclcpp::Node::SharedPtr to_domain_node = detail::get_node_for_domain(*impl_, to_domain_id, to_local_host_only);
 
   // Create a client for the 'from_domain'
   auto client = from_domain_node->create_client<ServiceT>(

--- a/include/domain_bridge/topic_bridge.hpp
+++ b/include/domain_bridge/topic_bridge.hpp
@@ -36,6 +36,14 @@ struct TopicBridge
   /// Domain ID that the publisher uses
   std::size_t to_domain_id;
 
+  // local host mode for subscriber
+  DomainBridgeOptions::LocalHostOnly from_local_host_only =
+    DomainBridgeOptions::LocalHostOnly::Default;
+
+  // local host mode for publisher
+  DomainBridgeOptions::LocalHostOnly to_local_host_only =
+    DomainBridgeOptions::LocalHostOnly::Default;
+
   /// Less-than operator.
   /**
    * Sort by 'from_domain_id',
@@ -55,6 +63,18 @@ struct TopicBridge
       return true;
     }
     if (to_domain_id > other.to_domain_id) {
+      return false;
+    }
+    if (from_local_host_only < other.from_local_host_only) {
+      return true;
+    }
+    if (from_local_host_only > other.from_local_host_only) {
+      return false;
+    }
+    if (to_local_host_only < other.to_local_host_only) {
+      return true;
+    }
+    if (to_local_host_only > other.to_local_host_only) {
       return false;
     }
     int name_compare = topic_name.compare(other.topic_name);

--- a/test/domain_bridge/test_domain_bridge.cpp
+++ b/test/domain_bridge/test_domain_bridge.cpp
@@ -65,7 +65,10 @@ TEST_F(TestDomainBridge, bridge_topic_valid)
   // Individual parameters
   {
     domain_bridge::DomainBridge bridge;
-    bridge.bridge_topic("foo", "test_msgs/msg/BasicTypes", 1u, 2u);
+    bridge.bridge_topic(
+      "foo", "test_msgs/msg/BasicTypes", 1u, 2u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
   }
   // Struct parameter
   {
@@ -81,21 +84,42 @@ TEST_F(TestDomainBridge, bridge_topic_valid)
   // Topic with namespace
   {
     domain_bridge::DomainBridge bridge;
-    bridge.bridge_topic("foo/bar/baz", "test_msgs/msg/BasicTypes", 1u, 2u);
+    bridge.bridge_topic(
+      "foo/bar/baz", "test_msgs/msg/BasicTypes", 1u, 2u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
   }
   // Multiple topics
   {
     domain_bridge::DomainBridge bridge;
-    bridge.bridge_topic("foo", "test_msgs/msg/BasicTypes", 1u, 2u);
-    bridge.bridge_topic("bar", "test_msgs/msg/BasicTypes", 1u, 2u);
-    bridge.bridge_topic("baz", "test_msgs/msg/BasicTypes", 1u, 2u);
+    bridge.bridge_topic(
+      "foo", "test_msgs/msg/BasicTypes", 1u, 2u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
+    bridge.bridge_topic(
+      "bar", "test_msgs/msg/BasicTypes", 1u, 2u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
+    bridge.bridge_topic(
+      "baz", "test_msgs/msg/BasicTypes", 1u, 2u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
   }
   // Same topic, different domains
   {
     domain_bridge::DomainBridge bridge;
-    bridge.bridge_topic("foo", "test_msgs/msg/BasicTypes", 1u, 2u);
-    bridge.bridge_topic("foo", "test_msgs/msg/BasicTypes", 1u, 3u);
-    bridge.bridge_topic("foo", "test_msgs/msg/BasicTypes", 2u, 1u);
+    bridge.bridge_topic(
+      "foo", "test_msgs/msg/BasicTypes", 1u, 2u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
+    bridge.bridge_topic(
+      "foo", "test_msgs/msg/BasicTypes", 1u, 3u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
+    bridge.bridge_topic(
+      "foo", "test_msgs/msg/BasicTypes", 2u, 1u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
   }
   // Same topic, different types
   // This use-case isn't clearly supported by ROS 2, see https://github.com/ros2/ros2/issues/1095
@@ -113,20 +137,29 @@ TEST_F(TestDomainBridge, bridge_topic_invalid)
   {
     domain_bridge::DomainBridge bridge;
     EXPECT_THROW(
-      bridge.bridge_topic("Not a v@lid topic name!", "test_msgs/msg/BasicTypes", 1u, 2u),
+      bridge.bridge_topic(
+        "Not a v@lid topic name!", "test_msgs/msg/BasicTypes", 1u, 2u,
+        domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+        domain_bridge::DomainBridgeOptions::LocalHostOnly::Default),
       rclcpp::exceptions::InvalidTopicNameError);
   }
   // Invalid type name
   {
     domain_bridge::DomainBridge bridge;
     EXPECT_THROW(
-      bridge.bridge_topic("foo", "not a valid message type", 1u, 2u), std::runtime_error);
+      bridge.bridge_topic(
+        "foo", "not a valid message type", 1u, 2u,
+        domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+        domain_bridge::DomainBridgeOptions::LocalHostOnly::Default), std::runtime_error);
   }
   // Same domain ID
   {
     testing::internal::CaptureStderr();
     domain_bridge::DomainBridge bridge;
-    bridge.bridge_topic("foo", "test_msgs/msg/BasicTypes", 1u, 1u);
+    bridge.bridge_topic(
+      "foo", "test_msgs/msg/BasicTypes", 1u, 1u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
     std::string stderr_output = testing::internal::GetCapturedStderr();
     EXPECT_THAT(
       stderr_output,
@@ -137,8 +170,14 @@ TEST_F(TestDomainBridge, bridge_topic_invalid)
   {
     testing::internal::CaptureStderr();
     domain_bridge::DomainBridge bridge;
-    bridge.bridge_topic("foo", "test_msgs/msg/BasicTypes", 1u, 2u);
-    bridge.bridge_topic("foo", "test_msgs/msg/BasicTypes", 1u, 2u);
+    bridge.bridge_topic(
+      "foo", "test_msgs/msg/BasicTypes", 1u, 2u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
+    bridge.bridge_topic(
+      "foo", "test_msgs/msg/BasicTypes", 1u, 2u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
     std::string stderr_output = testing::internal::GetCapturedStderr();
     EXPECT_THAT(
       stderr_output,
@@ -151,9 +190,18 @@ TEST_F(TestDomainBridge, bridge_topic_invalid)
   {
     testing::internal::CaptureStderr();
     domain_bridge::DomainBridge bridge;
-    bridge.bridge_topic("bar", "test_msgs/msg/Strings", 1u, 2u);
-    bridge.bridge_topic("foo", "test_msgs/msg/BasicTypes", 1u, 2u);
-    bridge.bridge_topic("foo", "test_msgs/msg/BasicTypes", 1u, 2u);
+    bridge.bridge_topic(
+      "bar", "test_msgs/msg/Strings", 1u, 2u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
+    bridge.bridge_topic(
+      "foo", "test_msgs/msg/BasicTypes", 1u, 2u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
+    bridge.bridge_topic(
+      "foo", "test_msgs/msg/BasicTypes", 1u, 2u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
     std::string stderr_output = testing::internal::GetCapturedStderr();
     EXPECT_THAT(
       stderr_output,
@@ -178,7 +226,9 @@ TEST_F(TestDomainBridge, add_to_executor_valid)
       "foo",
       "test_msgs/msg/BasicTypes",
       1u,
-      2u);
+      2u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
     rclcpp::executors::SingleThreadedExecutor executor;
     bridge.add_to_executor(executor);
   }
@@ -193,7 +243,9 @@ TEST_F(TestDomainBridge, add_to_executor_invalid)
       "foo",
       "test_msgs/msg/BasicTypes",
       1u,
-      2u);
+      2u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
     rclcpp::executors::SingleThreadedExecutor executor;
     bridge.add_to_executor(executor);
     EXPECT_THROW(bridge.add_to_executor(executor), std::runtime_error);
@@ -205,7 +257,9 @@ TEST_F(TestDomainBridge, add_to_executor_invalid)
       "foo",
       "test_msgs/msg/BasicTypes",
       1u,
-      2u);
+      2u,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
     rclcpp::executors::SingleThreadedExecutor executor1;
     rclcpp::executors::SingleThreadedExecutor executor2;
     bridge.add_to_executor(executor1);
@@ -270,6 +324,8 @@ TEST_F(TestDomainBridge, remap_topic_name_invalid)
   topic_bridge_options.remap_name(remap_name);
   EXPECT_THROW(
     bridge.bridge_topic(
-      topic_name, "test_msgs/msg/BasicTypes", 0, 2, topic_bridge_options),
+      topic_name, "test_msgs/msg/BasicTypes", 0, 2,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+      domain_bridge::DomainBridgeOptions::LocalHostOnly::Default, topic_bridge_options),
     rclcpp::exceptions::InvalidTopicNameError);
 }

--- a/test/domain_bridge/test_domain_bridge_end_to_end.cpp
+++ b/test/domain_bridge/test_domain_bridge_end_to_end.cpp
@@ -152,7 +152,9 @@ TEST_F(TestDomainBridgeEndToEnd, remap_topic_name)
   domain_bridge::TopicBridgeOptions topic_bridge_options;
   topic_bridge_options.remap_name(remap_name);
   bridge.bridge_topic(
-    topic_name, "test_msgs/msg/BasicTypes", kDomain1, kDomain2, topic_bridge_options);
+    topic_name, "test_msgs/msg/BasicTypes", kDomain1, kDomain2,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default, topic_bridge_options);
 
   pub->publish(test_msgs::msg::BasicTypes{});
   ScopedAsyncSpinner spinner{context_1_};
@@ -185,7 +187,9 @@ TEST_F(TestDomainBridgeEndToEnd, remap_topic_name_with_substitution)
   domain_bridge::TopicBridgeOptions topic_bridge_options;
   topic_bridge_options.remap_name(remap_name);
   bridge.bridge_topic(
-    topic_name, "test_msgs/msg/BasicTypes", kDomain1, kDomain2, topic_bridge_options);
+    topic_name, "test_msgs/msg/BasicTypes", kDomain1, kDomain2,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default, topic_bridge_options);
 
   pub->publish(test_msgs::msg::BasicTypes{});
   ScopedAsyncSpinner spinner{context_1_};
@@ -212,7 +216,9 @@ TEST_F(TestDomainBridgeEndToEnd, wait_for_subscription)
   topic_bridge_options.wait_for_subscription(true);
   ASSERT_TRUE(topic_bridge_options.wait_for_subscription());
   bridge.bridge_topic(
-    topic_name, "test_msgs/msg/BasicTypes", kDomain1, kDomain2, topic_bridge_options);
+    topic_name, "test_msgs/msg/BasicTypes", kDomain1, kDomain2,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default, topic_bridge_options);
 
   // bridge shouldn't be created until the subscription is up
   EXPECT_FALSE(poll_condition([pub]() {return pub->get_subscription_count() > 0;}, 5s));
@@ -248,7 +254,9 @@ TEST_F(TestDomainBridgeEndToEnd, auto_remove_no_subscription)
   topic_bridge_options.auto_remove(domain_bridge::TopicBridgeOptions::AutoRemove::OnNoSubscription);
   ASSERT_TRUE(topic_bridge_options.wait_for_subscription());
   bridge.bridge_topic(
-    topic_name, "test_msgs/msg/BasicTypes", kDomain1, kDomain2, topic_bridge_options);
+    topic_name, "test_msgs/msg/BasicTypes", kDomain1, kDomain2,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default, topic_bridge_options);
 
   // bridge shouldn't be created until the subscription is up
   EXPECT_FALSE(poll_condition([pub]() {return pub->get_subscription_count() > 0;}, 5s));
@@ -288,7 +296,9 @@ TEST_F(TestDomainBridgeEndToEnd, compress_mode)
   domain_bridge_options.mode(domain_bridge::DomainBridgeOptions::Mode::Compress);
   domain_bridge::DomainBridge bridge{domain_bridge_options};
   bridge.bridge_topic(
-    topic_name, "test_msgs/msg/BasicTypes", kDomain1, kDomain2);
+    topic_name, "test_msgs/msg/BasicTypes", kDomain1, kDomain2,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
 
   pub->publish(test_msgs::msg::BasicTypes{});
   ScopedAsyncSpinner spinner{context_1_};
@@ -318,7 +328,9 @@ TEST_F(TestDomainBridgeEndToEnd, decompress_mode)
   domain_bridge_options.mode(domain_bridge::DomainBridgeOptions::Mode::Decompress);
   domain_bridge::DomainBridge bridge{domain_bridge_options};
   bridge.bridge_topic(
-    topic_name, "test_msgs/msg/BasicTypes", kDomain1, kDomain2);
+    topic_name, "test_msgs/msg/BasicTypes", kDomain1, kDomain2,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
 
   rclcpp::Serialization<test_msgs::msg::BasicTypes> serializer;
   test_msgs::msg::BasicTypes msg;
@@ -388,7 +400,9 @@ TEST_F(TestDomainBridgeEndToEnd, domain_bridge_component_manager)
   const std::string topic_name("test_domain_bridge_component_manager");
   domain_bridge::DomainBridge bridge;
   bridge.bridge_topic(
-    topic_name, "test_msgs/msg/BasicTypes", kDomain1, kDomain2);
+    topic_name, "test_msgs/msg/BasicTypes", kDomain1, kDomain2,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
 
   // Add component manager, client, and node_2 (to receive the message)
   ScopedAsyncSpinner spinner{context_1_};

--- a/test/domain_bridge/test_domain_bridge_services.cpp
+++ b/test/domain_bridge/test_domain_bridge_services.cpp
@@ -133,7 +133,10 @@ TEST_F(TestDomainBridgeServices, bridge_service)
 
   // Bridge the publisher topic to domain 2 with a remap option
   domain_bridge::DomainBridge bridge;
-  bridge.bridge_service<test_msgs::srv::Empty>("my_service", kDomain1, kDomain2);
+  bridge.bridge_service<test_msgs::srv::Empty>(
+    "my_service", kDomain1, kDomain2,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
 
   std::atomic<bool> got_response = false;
   EXPECT_TRUE(poll_condition([cli]() {return cli->service_is_ready();}, 3s));

--- a/test/domain_bridge/test_qos_matching.cpp
+++ b/test/domain_bridge/test_qos_matching.cpp
@@ -80,7 +80,10 @@ TEST_F(TestDomainBridgeQosMatching, qos_matches_topic_exists_before_bridge)
 
   // Bridge the publisher topic to domain 2
   domain_bridge::DomainBridge bridge;
-  bridge.bridge_topic(topic_name, "test_msgs/msg/BasicTypes", domain_1_, domain_2_);
+  bridge.bridge_topic(
+    topic_name, "test_msgs/msg/BasicTypes", domain_1_, domain_2_,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
 
   // Wait for bridge publisher to appear on domain 2
   auto node_2 = std::make_shared<rclcpp::Node>(
@@ -110,7 +113,10 @@ TEST_F(TestDomainBridgeQosMatching, qos_matches_topic_exists_after_bridge)
 
   // Bridge the publisher topic to domain 2
   domain_bridge::DomainBridge bridge;
-  bridge.bridge_topic(topic_name, "test_msgs/msg/BasicTypes", domain_1_, domain_2_);
+  bridge.bridge_topic(
+    topic_name, "test_msgs/msg/BasicTypes", domain_1_, domain_2_,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
 
   // Wait for bridge publisher to appear on domain 2
   // It shouldn't be available yet
@@ -169,7 +175,9 @@ TEST_F(TestDomainBridgeQosMatching, qos_matches_topic_exists_multiple_publishers
   // Bridge the publisher topic to domain 2
   domain_bridge::DomainBridge bridge;
   bridge.bridge_topic(
-    topic_name, "test_msgs/msg/BasicTypes", domain_1_, domain_2_, bridge_options);
+    topic_name, "test_msgs/msg/BasicTypes", domain_1_, domain_2_,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default, bridge_options);
 
   // Wait for bridge publisher to appear on domain 2
   auto node_2 = std::make_shared<rclcpp::Node>(
@@ -197,7 +205,10 @@ TEST_F(TestDomainBridgeQosMatching, qos_matches_topic_does_not_exist)
 
   // Bridge a non-existent publisher topic to domain 2
   domain_bridge::DomainBridge bridge;
-  bridge.bridge_topic(topic_name, "test_msgs/msg/BasicTypes", domain_1_, domain_2_);
+  bridge.bridge_topic(
+    topic_name, "test_msgs/msg/BasicTypes", domain_1_, domain_2_,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
 
   // We do not expect a bridge publisher to appear because there is no input publisher
   auto node_2 = std::make_shared<rclcpp::Node>(
@@ -218,7 +229,10 @@ TEST_F(TestDomainBridgeQosMatching, qos_matches_always_automatic_liveliness)
 
   // Bridge the publisher topic to domain 2
   domain_bridge::DomainBridge bridge;
-  bridge.bridge_topic(topic_name, "test_msgs/msg/BasicTypes", domain_1_, domain_2_);
+  bridge.bridge_topic(
+    topic_name, "test_msgs/msg/BasicTypes", domain_1_, domain_2_,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default);
 
   // Wait for bridge publisher to appear on domain 2
   auto node_2 = std::make_shared<rclcpp::Node>(
@@ -261,7 +275,9 @@ TEST_F(TestDomainBridgeQosMatching, qos_matches_max_of_duration_policy)
   bridge_options.delay(std::chrono::milliseconds(1000));
   domain_bridge::DomainBridge bridge;
   bridge.bridge_topic(
-    topic_name, "test_msgs/msg/BasicTypes", domain_1_, domain_2_, bridge_options);
+    topic_name, "test_msgs/msg/BasicTypes", domain_1_, domain_2_,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default,
+    domain_bridge::DomainBridgeOptions::LocalHostOnly::Default, bridge_options);
 
   // Wait for bridge publisher to appear on domain 2
   auto node_2 = std::make_shared<rclcpp::Node>(


### PR DESCRIPTION
Nodes started with ROS_LOCALHOST=0 cannot communicate directly with nodes started with ROS_LOCALHOST=1 (at least with fastdds). With this change we can now specify the localhost mode for the "from" and "to". This allow to use ROS_LOCALHOST=0 to keep topic private, and selectively export the topic.

This was done by adding two new keys to yaml `from_local_host_only`/`to_local_host_only`, which can take "default", "enabled" and "disabled", mimicking the values in `rmw_localhost_only_e`.

The following configuration was used to forward the chatter topic from a localhost only talker to the general world:

```yaml
# Name of the domain bridge, used for node naming and logging
name: my_bridge
from_domain: 42
from_local_host_only: "enabled"
to_domain: 42
to_local_host_only: "disabled"
topics:
  # Bridge "/chatter" topic from doman ID 42 (local host only) to domain ID 42 (everywhere)
  chatter:
    type: std_msgs/msg/String
```

Can be tested by starting:

```bash
ROS_DOMAIN_ID=42 ROS_LOCALHOST_ONLY=1 ros2 run demo_nodes_cpp talker
```

```bash
ROS_DOMAIN_ID=42 ROS_LOCALHOST_ONLY=0 ros2 run demo_nodes_cpp listener
```


