### PR TITLE
Don't use rosbag2_cpp/typesupport_helpers.hpp for Jazzy and later

### DIFF
--- a/src/domain_bridge/domain_bridge.cpp
+++ b/src/domain_bridge/domain_bridge.cpp
@@ -35,7 +35,13 @@
 #include "rclcpp/generic_subscription.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/serialization.hpp"
+#include "rclcpp/version.h"
+#if RCLCPP_VERSION_MAJOR >= 25
+#include "rclcpp/typesupport_helpers.hpp"
+#else
+// Humble
 #include "rosbag2_cpp/typesupport_helpers.hpp"
+#endif
 #include "rosidl_typesupport_cpp/message_type_support.hpp"
 #include "rmw/types.h"
 
@@ -211,8 +217,13 @@ public:
       // Typesupport library already loaded
       return;
     }
-    loaded_typesupports_[type] = rosbag2_cpp::get_typesupport_library(
-      type, "rosidl_typesupport_cpp");
+    loaded_typesupports_[type] =
+#if RCLCPP_VERSION_MAJOR >= 25
+      rclcpp::get_typesupport_library(type, "rosidl_typesupport_cpp");
+#else
+      // Humble
+      rosbag2_cpp::get_typesupport_library(type, "rosidl_typesupport_cpp");
+#endif
   }
 
   std::shared_ptr<SerializedPublisher>


### PR DESCRIPTION
## Description

This fixes the following compile error in Jazzy:

    src/domain_bridge/domain_bridge.cpp:38:10: fatal error:
    rosbag2_cpp/typesupport_helpers.hpp: No such file or directory
       38 | #include "rosbag2_cpp/typesupport_helpers.hpp"
          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

It happens since rosbag2 release 0.26.10 and is caused by ros2/rosbag2#2017 and its backport to Jazzy (ros2/rclcpp#2902).

We keep the previous implementation, which is needed for Humble and add a new one, which works for Jazzy and later.


### Is this user-facing behavior change?

No

### Did you use Generative AI?

No
